### PR TITLE
allow whitespaces for attributes after '='

### DIFF
--- a/lib/surface/translator/parser.ex
+++ b/lib/surface/translator/parser.ex
@@ -89,10 +89,10 @@ defmodule Surface.Translator.Parser do
     |> concat(whitespace)
     |> optional(
       choice([
-        ignore(string("=")) |> concat(attribute_expr),
-        ignore(string("=")) |> concat(attribute_value),
-        ignore(string("=")) |> concat(integer(min: 1)),
-        ignore(string("=")) |> concat(boolean)
+        ignore(string("=")) |> concat(whitespace) |> concat(attribute_expr),
+        ignore(string("=")) |> concat(whitespace) |> concat(attribute_value),
+        ignore(string("=")) |> concat(whitespace) |> concat(integer(min: 1)),
+        ignore(string("=")) |> concat(whitespace) |> concat(boolean)
       ])
     )
     |> line()


### PR DESCRIPTION
Hi,

I had a problem to compile a file because I had a whitespace for an attribute between '=' and '{{' . And the line number given by the parser for this error was several lines before the line with the error, so it took me a while to figure out the error. I though it will be nice to allow whitespaces in the parser to avoid this problem in the future.
Thanks.