### PR TITLE
Fixes #36

### DIFF
--- a/lib/surface/live_view.ex
+++ b/lib/surface/live_view.ex
@@ -30,7 +30,7 @@ defmodule Surface.LiveView do
 
   """
 
-  defmacro __using__(_) do
+  defmacro __using__(opts) do
     quote do
       use Surface.BaseComponent, translator: Surface.Translator.LiveViewTranslator
       use Surface.API, include: [:property, :data]
@@ -49,7 +49,7 @@ defmodule Surface.LiveView do
       """
       property session, :map
 
-      use Phoenix.LiveView
+      use Phoenix.LiveView, unquote(opts)
     end
   end
 


### PR DESCRIPTION
Allows the Surface LiveView `using` macro to pass options to the Phoenix LiveView `using` macro, which enabled the specification of a default Live Layout.