### PR TITLE
Don't use Macro.underscore() to convert to kebab case

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -305,8 +305,8 @@ defmodule Surface do
   defp to_kebab_case(value) do
     value
     |> to_string()
-    |> Macro.underscore()
-    |> String.replace("_", "-")
+    |> String.replace(~r/([a-z])([A-Z])/, "\\1-\\2")
+    |> String.downcase()
   end
 
   defp runtime_error(message) do

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -76,6 +76,30 @@ defmodule HtmlTagTest do
       <div class="default1 default2 prop1 prop3"></div>
       """
     end
+
+    test "css class with periods in names" do
+      assigns = %{value1: true, value2: false, value3: true}
+      code =
+        ~H"""
+        <div class={{ "default.1", "default.2", "prop.1": @value1, prop2: @value2, prop3: @value3 }}/>
+        """
+
+      assert render_static(code) =~ """
+      <div class="default.1 default.2 prop.1 prop3"></div>
+      """
+    end
+
+    test "css class with underscores in names" do
+      assigns = %{value1: true, value2: false, value3: true}
+      code =
+        ~H"""
+        <div class={{ "default__1", "default__2", prop__1: @value1, prop2: @value2, prop3: @value3 }}/>
+        """
+
+      assert render_static(code) =~ """
+      <div class="default__1 default__2 prop__1 prop3"></div>
+      """
+    end
   end
 
   test "boolean attributes" do


### PR DESCRIPTION
Fixes #50 

I'm not confident this is the correct solution as I know it doesn't support everything that `Macro.underscore()` does. I removed the `0-9` that I originally suggested in the issue as it caused one of the css class tests to fail
