### PR TITLE
add helpers for live patch/live redirect

### DIFF
--- a/lib/surface/components/live_patch.ex
+++ b/lib/surface/components/live_patch.ex
@@ -1,0 +1,26 @@
+defmodule Surface.Components.LivePatch do
+  @moduledoc """
+  A module providing similar capabilities to the live_patch function
+  """
+  use Surface.Component
+
+  property(to, :string, required: true)
+  property(replace, :boolean, default: false)
+  property(class, :css_class, default: "")
+
+  def render(%{replace: replace} = assigns) do
+    link_state = if replace, do: "replace", else: "push"
+
+    ~H"""
+    <a
+      data-phx-link="patch"
+      data-phx-link-state={{ link_state }}
+      class={{ @class }}
+      href={{ @to }}
+      to={{ @to }}
+    >
+      {{ @inner_content.() }}
+    </a>
+    """
+  end
+end

--- a/lib/surface/components/live_redirect.ex
+++ b/lib/surface/components/live_redirect.ex
@@ -1,0 +1,26 @@
+defmodule Surface.Components.LiveRedirect do
+  @moduledoc """
+  A module providing similar capabilities to the live_redirect function
+  """
+  use Surface.Component
+
+  property(to, :string, required: true)
+  property(replace, :boolean, default: false)
+  property(class, :css_class, default: "")
+
+  def render(%{replace: replace} = assigns) do
+    link_state = if replace, do: "replace", else: "push"
+
+    ~H"""
+    <a
+      data-phx-link="redirect"
+      data-phx-link-state={{ link_state }}
+      class={{ @class }}
+      href={{ @to }}
+      to={{ @to }}
+    >
+      {{ @inner_content.() }}
+    </a>
+    """
+  end
+end


### PR DESCRIPTION
I went for two separate components instead of one with a property as I assumed the phoenix team had reasons for moving away from the single `live_link` helper to separate `patch`/`redirect` helpers

Resolves #54 