### PR TITLE
Add missing comma in .formatter.exs.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -13,6 +13,6 @@ locals_without_parens = [
 
 [
   locals_without_parens: locals_without_parens,
-  export: [locals_without_parens: locals_without_parens]
+  export: [locals_without_parens: locals_without_parens],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,7 +8,9 @@ locals_without_parens = [
   set: 2,
   set: 3,
   data: 3,
-  data: 2
+  data: 2,
+  slot: 1,
+  slot: 2
 ]
 
 [


### PR DESCRIPTION
Noticed this when I was trying to import the new export.

Also adding `slot/1` and `slot/2` to the export.