### PR TITLE
Drop camelCase to kebab-case auto-conversion

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -301,14 +301,6 @@ defmodule Surface do
     [{:safe, "\""}, value, {:safe, "\""}]
   end
 
-  # TODO: Find a better way to do this
-  defp to_kebab_case(value) do
-    value
-    |> to_string()
-    |> String.replace(~r/([a-z])([A-Z])/, "\\1-\\2")
-    |> String.downcase()
-  end
-
   defp runtime_error(message) do
     stacktrace =
       self()

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -199,7 +199,7 @@ defmodule Surface do
         {class, true} ->
           [to_kebab_case(class) | classes]
         class when is_binary(class) or is_atom(class) ->
-          [class | classes]
+          [to_string(class) | classes]
 
         _ ->
           classes

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -197,7 +197,7 @@ defmodule Surface do
     Enum.reduce(list, [], fn item, classes ->
       case item do
         {class, true} ->
-          [to_kebab_case(class) | classes]
+          [to_string(class) | classes]
         class when is_binary(class) or is_atom(class) ->
           [to_string(class) | classes]
 

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -199,7 +199,8 @@ defmodule Surface do
         {class, true} ->
           [to_kebab_case(class) | classes]
         class when is_binary(class) or is_atom(class) ->
-          [to_kebab_case(class) | classes]
+          [class | classes]
+
         _ ->
           classes
       end

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -123,7 +123,7 @@ defmodule HtmlTagTest do
       """
 
       assert render_static(code) =~ """
-             <div class="Default prop1"></div>
+             <div class="Default Prop1"></div>
              """
     end
   end

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -99,8 +99,32 @@ defmodule HtmlTagTest do
         """
 
       assert render_static(code) =~ """
-      <div class="default__1 default__2 prop__1 prop3"></div>
+             <div class="default__1 default__2 prop__1 prop3"></div>
+             """
+    end
+
+    test "css class defined with an atom" do
+      assigns = %{}
+
+      code = ~H"""
+      <div class={{:default}}/>
       """
+
+      assert render_static(code) =~ """
+             <div class="default"></div>
+             """
+    end
+
+    test "css class with uppercase letter" do
+      assigns = %{value1: true}
+
+      code = ~H"""
+      <div class={{ "Default", Prop1: @value1 }}/>
+      """
+
+      assert render_static(code) =~ """
+             <div class="Default prop1"></div>
+             """
     end
   end
 


### PR DESCRIPTION
Why:

* There are css architectures that use uppercase class names in their
  naming convention, for example, SUITCSS (https://suitcss.github.io/).
  Therefore we don't want to restrict that.

This change addresses the need by:

* Allowing binary or atom css classes to go through untouched, even in
  lists. When they're defined as a property we lose control over exactly
  how it's going to be named and that can also be improved, but not as
  big of a deal.

As a side note, I noticed that the project does not use `mix format`.
Any particular reason?