### PR TITLE
Creates a TextInput component

### DIFF
--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -18,7 +18,8 @@ defmodule Surface.API do
     :atom,
     :module,
     :changeset,
-    :form
+    :form,
+    :keyword
   ]
 
   @private_opts [:action, :to]

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -1,12 +1,37 @@
 defmodule Surface.Components.Form.TextInput do
+  @moduledoc """
+  Generates a text input.
+
+  Provides a wrapper for Phoenix.HTML.Form's `text_input/3` function.
+
+  All options passed via `opts` will be sent to `text_input/3`, `value` and
+  `class` can be set directly and will override anything in `opts`.
+
+
+  ## Examples
+
+  ```
+  <TextInput form="user" field="name" opts={{ [autofocus: "autofocus"] }}>
+  ```
+  """
+
   use Surface.Component
 
   import Phoenix.HTML.Form
 
+  @doc "An identifier for the form"
   property form, :string, required: true
+
+  @doc "An identifier for the input"
   property field, :string, required: true
+
+  @doc "Value to pre-populated the input"
   property value, :string
+
+  @doc "Class or classes to apply to the input"
   property class, :css_class
+
+  @doc "Keyword with options to be passed down to `text_input/3`"
   property opts, :keyword, default: []
 
   def render(assigns) do

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -1,18 +1,23 @@
 defmodule Surface.Components.Form.TextInput do
   use Surface.Component
 
+  import Phoenix.HTML.Form
+
+  property form, :string, required: true
   property field, :string, required: true
   property value, :string, default: ""
   property class, :css_class
 
   def render(assigns) do
     ~H"""
-    <input
-      type="text"
-      class={{ @class }}
-      id={{ @field }}
-      value={{ @value }}
-    />
+    {{
+      text_input(
+        String.to_atom(@form),
+        @field,
+        value: @value,
+        class: @class
+      )
+    }}
     """
   end
 end

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -7,6 +7,7 @@ defmodule Surface.Components.Form.TextInput do
   property field, :string, required: true
   property value, :string, default: ""
   property class, :css_class
+  property opts, :keyword, default: []
 
   def render(assigns) do
     ~H"""
@@ -14,8 +15,10 @@ defmodule Surface.Components.Form.TextInput do
       text_input(
         String.to_atom(@form),
         @field,
-        value: @value,
-        class: @class
+        [
+          value: @value,
+          class: @class,
+        ] ++ @opts
       )
     }}
     """

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -5,7 +5,7 @@ defmodule Surface.Components.Form.TextInput do
 
   property form, :string, required: true
   property field, :string, required: true
-  property value, :string, default: ""
+  property value, :string
   property class, :css_class
   property opts, :keyword, default: []
 

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -1,0 +1,18 @@
+defmodule Surface.Components.Form.TextInput do
+  use Surface.Component
+
+  property field, :string, required: true
+  property value, :string, default: ""
+  property class, :css_class
+
+  def render(assigns) do
+    ~H"""
+    <input
+      type="text"
+      class={{ @class }}
+      id={{ @field }}
+      value={{ @value }}
+    />
+    """
+  end
+end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -519,9 +519,7 @@ defmodule Surface.APITest do
 
     test "valid options" do
       code = """
-      alias Surface.APITest.ContextSetter
-      ContextSetter
-      context get form, from: ContextSetter, as: :my_form
+      context get form, from: Surface.APITest.ContextSetter, as: :my_form
       """
 
       assert eval(code) == :ok

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -520,6 +520,7 @@ defmodule Surface.APITest do
     test "valid options" do
       code = """
       alias Surface.APITest.ContextSetter
+      ContextSetter
       context get form, from: ContextSetter, as: :my_form
       """
 

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -1,8 +1,7 @@
 defmodule Surface.Components.Form.TextInputTest do
   use ExUnit.Case
 
-  alias Surface.Components.Form.TextInput
-  TextInput
+  alias Surface.Components.Form.TextInput, warn: false
 
   import ComponentTestHelper
 

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -32,7 +32,7 @@ defmodule Surface.Components.Form.TextInputTest do
       """
 
       assert render_live(code) =~ """
-             <input autofocus="autofocus" id="myid" name="user[name]" type="text" value=""/>
+             <input autofocus="autofocus" id="myid" name="user[name]" type="text"/>
              """
     end
   end

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -6,24 +6,6 @@ defmodule Surface.Components.Form.TextInputTest do
   import Surface
   import ComponentTestHelper
 
-  defmodule Input do
-    use Surface.Component
-
-    property value, :string
-    property opts, :keyword
-
-    def render(assigns) do
-      ~H"""
-      <TextInput
-        form="user"
-        field="name"
-        value={{ @value }}
-        opts={{ @opts }}
-      />
-      """
-    end
-  end
-
   describe "Without LiveView" do
     test "empty input" do
       code = """

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -2,6 +2,7 @@ defmodule Surface.Components.Form.TextInputTest do
   use ExUnit.Case
 
   alias Surface.Components.Form.TextInput
+  TextInput
 
   import ComponentTestHelper
 

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -1,0 +1,58 @@
+defmodule Surface.Components.Form.TextInputTest do
+  use ExUnit.Case
+
+  alias Surface.Components.Form.TextInput
+
+  import Surface
+  import ComponentTestHelper
+
+  defmodule Input do
+    use Surface.Component
+
+    property value, :string
+    property opts, :keyword
+
+    def render(assigns) do
+      ~H"""
+      <TextInput
+        form="user"
+        field="name"
+        value={{ @value }}
+        opts={{ @opts }}
+      />
+      """
+    end
+  end
+
+  describe "Without LiveView" do
+    test "empty input" do
+      code = """
+      <TextInput form="user" field="name" />
+      """
+
+      assert render_live(code) =~ """
+             <input id="user_name" name="user[name]" type="text" value=""/>
+             """
+    end
+
+    test "setting the value" do
+      code = """
+      <TextInput form="user" field="name" value="myname" />
+      """
+
+      assert render_live(code) =~ """
+             <input id="user_name" name="user[name]" type="text" value="myname"/>
+             """
+    end
+
+    test "passing other options" do
+      code = """
+      <TextInput form="user" field="name" opts={{ [id: "myid", autofocus: "autofocus"] }} />
+      """
+
+      assert render_live(code) =~ """
+             <input autofocus="autofocus" id="myid" name="user[name]" type="text" value=""/>
+             """
+    end
+  end
+end

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -3,7 +3,6 @@ defmodule Surface.Components.Form.TextInputTest do
 
   alias Surface.Components.Form.TextInput
 
-  import Surface
   import ComponentTestHelper
 
   describe "Without LiveView" do
@@ -13,7 +12,7 @@ defmodule Surface.Components.Form.TextInputTest do
       """
 
       assert render_live(code) =~ """
-             <input id="user_name" name="user[name]" type="text" value=""/>
+             <input id="user_name" name="user[name]" type="text"/>
              """
     end
 

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -34,13 +34,8 @@ defmodule ContextTest do
   defmodule Inner do
     use Surface.Component
 
-    alias ContextTest.InnerWrapper
-    InnerWrapper
-    alias ContextTest.Outer
-    Outer
-
-    context get field, from: Outer
-    context get field, from: InnerWrapper, as: :other_field
+    context get field, from: ContextTest.Outer
+    context get field, from: ContextTest.InnerWrapper, as: :other_field
 
     def render(assigns) do
       ~H"""

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -35,7 +35,9 @@ defmodule ContextTest do
     use Surface.Component
 
     alias ContextTest.InnerWrapper
+    InnerWrapper
     alias ContextTest.Outer
+    Outer
 
     context get field, from: Outer
     context get field, from: InnerWrapper, as: :other_field


### PR DESCRIPTION
Why:

* There's a few components that are common enough that we can define
  ourselves, namely related with forms. Moreover that will eventually give
  us the chance to create form wrappers that abstract over repeated
  complexity of implementing said forms.

  Related to msaraiva/surface#32

This change addresses the need by:

* Creating a new namespace `Form`
* Adding a very simple `TextInput` component which tries to mimic
  `Phoenix.HTML.Form`. There are a couple of issues with different
  levels of priority that could be addressed before finalizing this:

  1. There is no way to pass a "blob" of properties along. This would be
  needed, because we can't/don't want to set a property in the component
  for every property the html element supports. (msaraiva/surface#2)
  2. It would be nice to be able to only set an attribute if the
  property is non empty. This is particularly interesting for non
  required properties. For example, if no class attribute is passed,
  it still sets `class=""`.

  This might be a moot problem after number 1 is solved, as we can
  simply not set class as property.