### PR TITLE
Adds a :properties directive

### DIFF
--- a/lib/surface/translator.ex
+++ b/lib/surface/translator.ex
@@ -14,9 +14,9 @@ defmodule Surface.Translator do
 
   @optional_callbacks prepare: 2
 
-  @tag_directives [":for", ":if", ":show", ":debug", ":props"]
+  @tag_directives [":for", ":if", ":show", ":debug", ":properties"]
 
-  @component_directives [":for", ":if", ":let", ":debug", ":props"]
+  @component_directives [":for", ":if", ":let", ":debug", ":properties"]
 
   @template_directives [":let"]
 
@@ -409,7 +409,7 @@ defmodule Surface.Translator do
     parts
   end
 
-  defp handle_directive({":props", {:attribute_expr, [expr]}, _line}, parts, node, _caller) do
+  defp handle_directive({":properties", {:attribute_expr, [expr]}, _line}, parts, node, _caller) do
     {open, children, close} = parts
     {_, _, _, %{translator: translator}} = node
 

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -15,6 +15,32 @@ defmodule Surface.DirectivesTest do
     end
   end
 
+  defmodule DivWithDynamicProps do
+    use Surface.Component
+
+    def render(assigns) do
+      ~H"""
+      <div class="myclass" :props={{ @props }}>{{ @inner_content.([]) }}</div>
+      """
+    end
+  end
+
+  describe ":props" do
+    test "with html tags" do
+      code = """
+      <DivWithDynamicProps :props={{ %{id: "myid"} }}>
+        Some Text
+      </DivWithDynamicProps>
+      """
+
+      assert render_live(code, %{}) =~ """
+             <div class="myclass" id="myid">
+               Some Text
+             </div>
+             """
+    end
+  end
+
   describe ":for" do
     test "in components" do
       assigns = %{items: [1, 2]}

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -20,15 +20,15 @@ defmodule Surface.DirectivesTest do
 
     def render(assigns) do
       ~H"""
-      <div class="myclass" :props={{ @props }}>{{ @inner_content.([]) }}</div>
+      <div class="myclass" :properties={{}}>{{ @inner_content.([]) }}</div>
       """
     end
   end
 
-  describe ":props" do
+  describe ":properties" do
     test "with html tags" do
       code = """
-      <DivWithDynamicProps :props={{ %{id: "myid"} }}>
+      <DivWithDynamicProps :properties={{ %{id: "myid"} }}>
         Some Text
       </DivWithDynamicProps>
       """


### PR DESCRIPTION
Why:

* This allows sending props down to the underlying components without
  having to redefine them all. This is just an experience on how it
  could work for html tags

 Related to #2 

This change addresses the need by:

* Adding a :properties directive that for a component will take a map and
  add it to the props in the assigns as `__dynamic_props__`. If it is a tag,
  it will go over those `__dynamic_props__` and add them as attributes.

Notes:   
* Could not use :props as it's already used by slots.
* On the html tag don't really need the value of the directive, but it's
   not registered as a directive otherwise. Might look into that later.
* Not a fan of relying on the position in the lists, but couldn't figure out a better way, tbh.