### PR TITLE
Add Link component.

### DIFF
--- a/lib/surface/components/link.ex
+++ b/lib/surface/components/link.ex
@@ -1,0 +1,60 @@
+defmodule Surface.Components.Link do
+  @moduledoc """
+  Generates a hyperlink.
+
+  Provides a wrapper for Phoenix.HTML.Link's `link/2` function.
+
+  All options passed via `opts` will be sent to `link/2`, `label` and `class` can
+  be set directly and will override anything in `opts`.
+
+  ## Examples
+  ```
+  <Link
+    label="user"
+    to="/users/1"
+    class="is-danger"
+    opts={{ method: :delete, data: [confirm: "Really?"] }}
+  />
+
+  <Link
+    to="/users/1"
+    class="is-link"
+  >
+    <span>user</span>
+  </Link>
+  ```
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Link, only: [link: 2]
+
+  @doc "Place to link to"
+  property to, :string, required: true
+
+  @doc "Class or classes to apply to the link"
+  property class, :css_class
+
+  @doc "Keyword with options to be passed down to `link/2`"
+  property opts, :keyword, default: []
+
+  @doc """
+  The label for the generated `<a>` alement, if no content (default slot) is
+  provided.
+  """
+  property label, :string
+
+  @doc """
+  The content of the generated `<a>` element. If no content is provided,
+  the value of property `label` is used instead.
+  """
+  slot default
+
+  def render(assigns) do
+    children = ~H"<slot>{{ @label }}</slot>"
+
+    ~H"""
+    {{ link [to: @to, class: @class] ++ @opts, do: children }}
+    """
+  end
+end

--- a/test/components/link_test.exs
+++ b/test/components/link_test.exs
@@ -1,0 +1,59 @@
+defmodule Surface.Components.LinkTest do
+  use ExUnit.Case
+
+  alias Surface.Components.Link, warn: false
+
+  import ComponentTestHelper
+
+  describe "Without LiveView" do
+    test "creates a link with label" do
+      code = """
+      <Link label="user" to="/users/1" />
+      """
+
+      assert render_live(code) =~ """
+             <a href="/users/1">user</a>
+             """
+    end
+
+    test "creates a link without label" do
+      code = """
+      <Link to="/users/1" />
+      """
+
+      assert render_live(code) =~ """
+             <a href="/users/1"></a>
+             """
+    end
+
+    test "creates a link with default slot" do
+      code = """
+      <Link to="/users/1"><span>user</span></Link>
+      """
+
+      assert render_live(code) =~ """
+             <a href="/users/1"><span>user</span></a>
+             """
+    end
+
+    test "setting the class" do
+      code = """
+      <Link label="user" to="/users/1" class="link" />
+      """
+
+      assert render_live(code) =~ """
+             <a class="link" href="/users/1">user</a>
+             """
+    end
+
+    test "passing other options" do
+      code = """
+      <Link label="user" to="/users/1" class="link" opts={{ method: :delete, data: [confirm: "Really?"], csrf_token: "token" }} />
+      """
+
+      assert render_live(code) =~ """
+             <a class="link" data-confirm="Really?" data-csrf="token" data-method="delete" data-to="/users/1" href="/users/1" rel="nofollow">user</a>
+             """
+    end
+  end
+end


### PR DESCRIPTION
Why:

This provides a component that wraps `Phoenix.HTML.link/2` and passes through all options given to it. This is needed so that we can add to our built-ins that provide developers all the tools they need to write component based applications.

This is a follow up to #70 