### PR TITLE
Adds an option for inline parsing of elements

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -58,8 +58,10 @@ defmodule Surface do
   @doc """
   Translates Surface code into Phoenix templates.
   """
-  defmacro sigil_H({:<<>>, _, [string]}, _) do
+  defmacro sigil_H({:<<>>, _, [string]}, opts) do
     line_offset = __CALLER__.line + 1
+
+    string = if opts == 'i', do: String.trim_trailing(string), else: string
 
     string
     |> Surface.Translator.run(line_offset, __CALLER__, __CALLER__.file)


### PR DESCRIPTION
Why:

* In some situations we might was to render Surface code to inline into
  other pieces of Surface code

This change addresses the need by:

* Adding an optional `i` to the H sigil that removes the final new line

Note: Not even sure if we want this, but it came up in #71 and I decided to give it a go.