### PR TITLE
Adds Submit button

### DIFF
--- a/lib/surface/components/form/submit.ex
+++ b/lib/surface/components/form/submit.ex
@@ -1,0 +1,33 @@
+defmodule Surface.Components.Form.Submit do
+  @moduledoc """
+  Generates a submit button to send the form.
+
+  All options are forwarded to the underlying `Phoenix.HTML.Form.submit/3`
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form, only: [submit: 2]
+
+  @doc "The text to be used in the button"
+  property text, :string
+
+  @doc "Class or classes to apply to the button"
+  property class, :css_class
+
+  @doc "Keyword list with options to be passed down to `submit/3`"
+  property opts, :keyword, default: []
+
+  @doc "Slot used for having children other than plaintext in the button"
+  slot default
+
+  def render(assigns) do
+    children = ~H"<slot>{{ @text }}</slot>"
+
+    ~H"""
+    {{
+      submit [class: @class] ++ @opts, do: children
+    }}
+    """
+  end
+end

--- a/lib/surface/components/form/submit.ex
+++ b/lib/surface/components/form/submit.ex
@@ -9,8 +9,8 @@ defmodule Surface.Components.Form.Submit do
 
   import Phoenix.HTML.Form, only: [submit: 2]
 
-  @doc "The text to be used in the button"
-  property text, :string
+  @doc "The label to be used in the button"
+  property label, :string
 
   @doc "Class or classes to apply to the button"
   property class, :css_class
@@ -18,11 +18,11 @@ defmodule Surface.Components.Form.Submit do
   @doc "Keyword list with options to be passed down to `submit/3`"
   property opts, :keyword, default: []
 
-  @doc "Slot used for having children other than plaintext in the button"
+  @doc "Slot used for having children other than plain text in the button"
   slot default
 
   def render(assigns) do
-    children = ~H"<slot>{{ @text }}</slot>"
+    children = ~H"<slot>{{ @label }}</slot>"
 
     ~H"""
     {{

--- a/test/components/form/submit_test.exs
+++ b/test/components/form/submit_test.exs
@@ -1,0 +1,49 @@
+defmodule Surface.Components.Form.SubmitTest do
+  use ExUnit.Case
+
+  alias Surface.Components.Form.Submit, warn: false
+
+  import ComponentTestHelper
+
+  test "text only" do
+    code = """
+    <Submit text="Submit" />
+    """
+
+    assert render_live(code) =~ """
+           <button type="submit">Submit</button>
+           """
+  end
+
+  test "with class" do
+    code = """
+    <Submit text="Submit" class="btn" />
+    """
+
+    assert render_live(code) =~ """
+           <button class="btn" type="submit">Submit</button>
+           """
+  end
+
+  test "with options" do
+    code = """
+    <Submit text="Submit" class="btn" opts={{ id: "submit-btn" }} />
+    """
+
+    assert render_live(code) =~ """
+           <button class="btn" id="submit-btn" type="submit">Submit</button>
+           """
+  end
+
+  test "with children" do
+    code = """
+    <Submit class="btn">
+      <span>Submit</span>
+    </Submit>
+    """
+
+    assert render_live(code) =~ """
+           <button class="btn" type="submit"><span>Submit</span></button>
+           """
+  end
+end

--- a/test/components/form/submit_test.exs
+++ b/test/components/form/submit_test.exs
@@ -5,9 +5,9 @@ defmodule Surface.Components.Form.SubmitTest do
 
   import ComponentTestHelper
 
-  test "text only" do
+  test "label only" do
     code = """
-    <Submit text="Submit" />
+    <Submit label="Submit" />
     """
 
     assert render_live(code) =~ """
@@ -17,7 +17,7 @@ defmodule Surface.Components.Form.SubmitTest do
 
   test "with class" do
     code = """
-    <Submit text="Submit" class="btn" />
+    <Submit label="Submit" class="btn" />
     """
 
     assert render_live(code) =~ """
@@ -27,7 +27,7 @@ defmodule Surface.Components.Form.SubmitTest do
 
   test "with options" do
     code = """
-    <Submit text="Submit" class="btn" opts={{ id: "submit-btn" }} />
+    <Submit label="Submit" class="btn" opts={{ id: "submit-btn" }} />
     """
 
     assert render_live(code) =~ """


### PR DESCRIPTION
Why:

* In order to have a functional form this is missing and should be part
  of the built in components

This change addresses the need by:

* Adding a Submit component that forwards options to Phoenix.HTML.Form
* Ensuring it works with children via a default slot