### PR TITLE
Fix unicode conversion error

### DIFF
--- a/lib/surface/translator.ex
+++ b/lib/surface/translator.ex
@@ -47,7 +47,7 @@ defmodule Surface.Translator do
     |> prepare(caller)
     |> prepend_context()
     |> translate(caller)
-    |> IO.iodata_to_binary()
+    |> IO.chardata_to_string()
   end
 
   @doc """

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -64,6 +64,18 @@ defmodule HtmlTagTest do
              <div @click.away="open = false"></div>
              """
     end
+
+    test "with utf-8 attribute value" do
+      assigns = %{}
+
+      code = ~H"""
+      <div title="héllo"/>
+      """
+
+      assert render_static(code) =~ """
+             <div title="héllo"></div>
+             """
+    end
   end
 
   describe "css class attributes" do


### PR DESCRIPTION
Fixes https://github.com/msaraiva/surface/issues/77

From the [documentation](https://hexdocs.pm/elixir/IO.html#iodata_to_binary/1):
> Notice that this function (iodata_to_binary/1) treats integers in the given IO data as raw bytes and does not perform any kind of encoding conversion. If you want to convert from a charlist to a UTF-8-encoded string, use chardata_to_string/1 instead. For more information about IO data and chardata, see the "IO data" section in the module documentation.