### PR TITLE
[Issue #73] Do not generate attributes for nil values

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -139,6 +139,16 @@ defmodule Surface do
   end
 
   @doc false
+  def attr(_key, nil) do
+    []
+  end
+
+  def attr(key, value) do
+    value = attr_value(key, value)
+    [key, "=", quot(value)]
+  end
+
+  @doc false
   def attr_value(attr, value) do
     if String.Chars.impl_for(value) do
       value

--- a/lib/surface/translator/tag_translator.ex
+++ b/lib/surface/translator/tag_translator.ex
@@ -169,7 +169,7 @@ defmodule Surface.Translator.TagTranslator do
 
   defp translate_attribute_assignment(key, value, %{spaces: spaces}) do
     [space1, space2, space3] = spaces
-    [space1, key, space2, "=", space3, wrap_unsafe_value(key, value)]
+    [space1, "<%= attr(\"", key, "\",", space2, value_to_code(value), ") %>", space3]
   end
 
   defp value_to_code({:attribute_expr, expr, _}) do

--- a/lib/surface/translator/tag_translator.ex
+++ b/lib/surface/translator/tag_translator.ex
@@ -81,8 +81,7 @@ defmodule Surface.Translator.TagTranslator do
   defp translate_attributes(attributes) do
     for {key, value, meta} <- attributes do
       value = replace_attribute_expr(value)
-
-      if value_is_empty_list?(value), do: [], else: translate_attribute(key, value, meta)
+      translate_attribute(key, value, meta)
     end
   end
 
@@ -203,11 +202,5 @@ defmodule Surface.Translator.TagTranslator do
 
   defp replace_attribute_expr(value) do
     value
-  end
-
-  defp value_is_empty_list?(value) do
-    whitespace_codepoint = 32
-
-    value |> is_list and value |> Enum.filter(&(&1 !== whitespace_codepoint)) |> Enum.empty?
   end
 end

--- a/lib/surface/translator/tag_translator.ex
+++ b/lib/surface/translator/tag_translator.ex
@@ -81,7 +81,8 @@ defmodule Surface.Translator.TagTranslator do
   defp translate_attributes(attributes) do
     for {key, value, meta} <- attributes do
       value = replace_attribute_expr(value)
-      translate_attribute(key, value, meta)
+
+      if value_is_nil?(value), do: [], else: translate_attribute(key, value, meta)
     end
   end
 
@@ -202,5 +203,9 @@ defmodule Surface.Translator.TagTranslator do
 
   defp replace_attribute_expr(value) do
     value
+  end
+
+  defp value_is_nil?(value) do
+    is_list(value) and value |> Enum.filter(&(&1 !== 32)) |> Enum.empty?
   end
 end

--- a/lib/surface/translator/tag_translator.ex
+++ b/lib/surface/translator/tag_translator.ex
@@ -82,7 +82,7 @@ defmodule Surface.Translator.TagTranslator do
     for {key, value, meta} <- attributes do
       value = replace_attribute_expr(value)
 
-      if value_is_nil?(value), do: [], else: translate_attribute(key, value, meta)
+      if value_is_empty_list?(value), do: [], else: translate_attribute(key, value, meta)
     end
   end
 
@@ -205,7 +205,9 @@ defmodule Surface.Translator.TagTranslator do
     value
   end
 
-  defp value_is_nil?(value) do
-    is_list(value) and value |> Enum.filter(&(&1 !== 32)) |> Enum.empty?
+  defp value_is_empty_list?(value) do
+    whitespace_codepoint = 32
+
+    value |> is_list and value |> Enum.filter(&(&1 !== whitespace_codepoint)) |> Enum.empty?
   end
 end

--- a/lib/surface/translator/tag_translator.ex
+++ b/lib/surface/translator/tag_translator.ex
@@ -131,7 +131,17 @@ defmodule Surface.Translator.TagTranslator do
   defp translate_attribute_assignment(key, {:attribute_expr, [expr], _}, %{spaces: spaces})
        when key in @boolean_attributes do
     [space1, space2, space3] = spaces
-    [space1, "<%= boolean_attr(\"", key, "\",", space2, expr, ") %>", space3]
+
+    [
+      space1,
+      "<%= boolean_attr(\"",
+      key,
+      "\",",
+      space2,
+      expr,
+      ") %>",
+      space3
+    ]
   end
 
   defp translate_attribute_assignment("class" = key, value, %{spaces: spaces}) do
@@ -146,7 +156,14 @@ defmodule Surface.Translator.TagTranslator do
         nil
       )
 
-    [space1, key, space2, "=", space3, wrap_safe_value(value)]
+    [
+      space1,
+      key,
+      space2,
+      "=",
+      space3,
+      wrap_safe_value(value)
+    ]
   end
 
   defp translate_attribute_assignment("style" = key, value, meta) do
@@ -169,7 +186,17 @@ defmodule Surface.Translator.TagTranslator do
 
   defp translate_attribute_assignment(key, value, %{spaces: spaces}) do
     [space1, space2, space3] = spaces
-    [space1, "<%= attr(\"", key, "\",", space2, value_to_code(value), ") %>", space3]
+
+    [
+      space1,
+      "<%= attr(\"",
+      key,
+      "\",",
+      space2,
+      value_to_code(value),
+      ") %>",
+      space3
+    ]
   end
 
   defp value_to_code({:attribute_expr, expr, _}) do
@@ -182,10 +209,6 @@ defmodule Surface.Translator.TagTranslator do
 
   defp wrap_safe_value(value) do
     [~S("), "<%= ", value_to_code(value), " %>", ~S(")]
-  end
-
-  defp wrap_unsafe_value(key, value) do
-    [~S("), "<%= attr_value(\"", key, "\", ", value_to_code(value), ") %>", ~S(")]
   end
 
   defp replace_attribute_expr(value) when is_list(value) do

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -219,6 +219,18 @@ defmodule Surface.DirectivesTest do
              """
     end
 
+    test "nil events" do
+      assigns = %{click: nil}
+
+      code = ~H"""
+      <button :on-phx-click={{ @click }}>No handler attached</button>
+      """
+
+      assert render_static(code) =~ """
+             <button >No handler attached</button>
+             """
+    end
+
     test "do not translate invalid events" do
       assigns = %{}
 

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -171,18 +171,6 @@ defmodule HtmlTagTest do
            """
   end
 
-  test "attributes with no value" do
-    assigns = %{}
-
-    code = ~H"""
-    <p class="" id=" ">Hello World</p>
-    """
-
-    assert render_static(code) =~ """
-           <p>Hello World</p>
-           """
-  end
-
   describe "style attibute" do
     test "as string" do
       assigns = %{}

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -171,6 +171,18 @@ defmodule HtmlTagTest do
            """
   end
 
+  test "attributes with no value" do
+    assigns = %{}
+
+    code = ~H"""
+    <p class="" id=" ">Hello World</p>
+    """
+
+    assert render_static(code) =~ """
+           <p>Hello World</p>
+           """
+  end
+
   describe "style attibute" do
     test "as string" do
       assigns = %{}

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -162,6 +162,18 @@ defmodule HtmlTagTest do
              <div class="Default Prop1"></div>
              """
     end
+
+    test "css class with nil value" do
+      assigns = %{}
+
+      code = ~H"""
+      <div class={{nil}}/>
+      """
+
+      assert render_static(code) =~ """
+             <div class=\"\"></div>
+             """
+    end
   end
 
   test "boolean attributes" do
@@ -217,6 +229,18 @@ defmodule HtmlTagTest do
 
       assert render_static(code) =~ """
              <div style="height: 10px;"></div>
+             """
+    end
+
+    test "properties with nil values" do
+      assigns = %{nil_value: nil}
+
+      code = ~H"""
+      <div style="height: {{ @nil_value }}, width: {{ @nil_value }};"/>
+      """
+
+      assert render_static(code) =~ """
+             <div style=\"\"></div>
              """
     end
 

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -76,6 +76,18 @@ defmodule HtmlTagTest do
              <div title="héllo"></div>
              """
     end
+
+    test "attributes as nil" do
+      assigns = %{id: nil, title: nil}
+
+      code = ~H"""
+      <p id={{ @id }} title={{ @title }}>Hello World</p>
+      """
+
+      assert render_static(code) =~ """
+             <p  >Hello World</p>
+             """
+    end
   end
 
   describe "css class attributes" do

--- a/test/translator_test.exs
+++ b/test/translator_test.exs
@@ -156,11 +156,10 @@ defmodule TranslatorTest do
 
     assert translated =~ """
            <div
-             label="<%= attr_value("label", "label") %>"
+             <%= attr("label","label") %>
              disabled
-             click=
-               "<%= attr_value("click", "event") %>"
-           ></div>\
+             <%= attr("click","event") %>
+               \n></div>
            """
   end
 


### PR DESCRIPTION
Proposed fix for #73 

Works for both cases when an attribute string is empty, or has empty whitespace. Not very pretty but still getting up to speed on this codebase.