### PR TITLE
Add support for co-located .sface templates

### DIFF
--- a/lib/surface/component.ex
+++ b/lib/surface/component.ex
@@ -36,13 +36,13 @@ defmodule Surface.Component do
       end
 
     quote do
+      @before_compile Surface.Renderer
       use Phoenix.LiveComponent
       use Surface.BaseComponent, translator: unquote(translator)
       use Surface.API, include: [:property, :slot, :context]
       import Phoenix.HTML
 
       @behaviour unquote(__MODULE__)
-      @before_compile Surface.Renderer
       @before_compile Surface.ContentHandler
 
       if unquote(translator) == Surface.Translator.SlotableTranslator do

--- a/lib/surface/component.ex
+++ b/lib/surface/component.ex
@@ -42,6 +42,7 @@ defmodule Surface.Component do
       import Phoenix.HTML
 
       @behaviour unquote(__MODULE__)
+      @before_compile Surface.Renderer
       @before_compile Surface.ContentHandler
 
       if unquote(translator) == Surface.Translator.SlotableTranslator do

--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -55,6 +55,7 @@ defmodule Surface.LiveComponent do
       use Phoenix.LiveComponent
       use Surface.BaseComponent, translator: Surface.Translator.LiveComponentTranslator
 
+      @before_compile Surface.Renderer
       @before_compile unquote(__MODULE__)
 
       use Surface.API, include: [:property, :slot, :data, :context]

--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -52,10 +52,10 @@ defmodule Surface.LiveComponent do
 
   defmacro __using__(_) do
     quote do
+      @before_compile Surface.Renderer
       use Phoenix.LiveComponent
       use Surface.BaseComponent, translator: Surface.Translator.LiveComponentTranslator
 
-      @before_compile Surface.Renderer
       @before_compile unquote(__MODULE__)
 
       use Surface.API, include: [:property, :slot, :data, :context]

--- a/lib/surface/live_view.ex
+++ b/lib/surface/live_view.ex
@@ -36,6 +36,7 @@ defmodule Surface.LiveView do
       use Surface.API, include: [:property, :data]
       import Phoenix.HTML
 
+      @before_compile Surface.Renderer
       @before_compile unquote(__MODULE__)
 
       @doc "The id of the live view"

--- a/lib/surface/renderer.ex
+++ b/lib/surface/renderer.ex
@@ -1,0 +1,70 @@
+defmodule Surface.Renderer do
+  @moduledoc false
+
+  defmacro __before_compile__(env) do
+    render? = Module.defines?(env.module, {:render, 1})
+    root = Path.dirname(env.file)
+    filename = template_filename(env)
+    template = Path.join(root, filename)
+
+    case {render?, File.exists?(template)} do
+      {true, true} ->
+        IO.warn(
+          "ignoring template #{inspect(template)} because the component " <>
+            "#{inspect(env.module)} defines a render/1 function",
+          Macro.Env.stacktrace(env)
+        )
+
+        :ok
+
+      {true, false} ->
+        :ok
+
+      {false, true} ->
+        ast =
+          template
+          |> File.read!()
+          |> Surface.Translator.run(0, env.module, template)
+          |> EEx.compile_string(
+            engine: Phoenix.LiveView.Engine,
+            line: 0,
+            file: template
+          )
+
+        quote do
+          @file unquote(template)
+          @external_resource unquote(template)
+          def render(var!(assigns)) do
+            unquote(ast)
+          end
+        end
+
+      _ ->
+        message = ~s'''
+        render/1 was not implemented for #{inspect(env.module)}.
+
+        Make sure to either explicitly define a render/1 clause with a Surface template:
+
+            def render(assigns) do
+              ~H"""
+              ...
+              """
+            end
+
+        Or create a file at #{inspect(template)} with the Surface template.
+        '''
+
+        IO.warn(message, Macro.Env.stacktrace(env))
+
+        :ok
+    end
+  end
+
+  defp template_filename(env) do
+    env.module
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+    |> Kernel.<>(".sface")
+  end
+end

--- a/lib/surface/renderer.ex
+++ b/lib/surface/renderer.ex
@@ -24,7 +24,7 @@ defmodule Surface.Renderer do
         ast =
           template
           |> File.read!()
-          |> Surface.Translator.run(0, env.module, template)
+          |> Surface.Translator.run(0, env, template)
           |> EEx.compile_string(
             engine: Phoenix.LiveView.Engine,
             line: 0,
@@ -56,7 +56,12 @@ defmodule Surface.Renderer do
 
         IO.warn(message, Macro.Env.stacktrace(env))
 
-        :ok
+        quote do
+          @external_resource unquote(template)
+          def render(_assigns) do
+            raise unquote(message)
+          end
+        end
     end
   end
 

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -1,0 +1,33 @@
+defmodule Surface.RendererTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.RendererTest.Components.ComponentWithExternalTemplate
+  alias Surface.RendererTest.Components.LiveComponentWithExternalTemplate
+  alias Surface.RendererTest.Components.LiveViewWithExternalTemplate
+
+  import ComponentTestHelper
+
+  defmodule View do
+    use Surface.LiveView
+
+    def render(assigns) do
+      ~H"""
+      <ComponentWithExternalTemplate/>
+      <LiveComponentWithExternalTemplate/>
+      <LiveViewWithExternalTemplate id="live_view" />
+      """
+    end
+  end
+
+  test "Component rendering external template" do
+    assert render_live(View) =~ "the rendered content of the component"
+  end
+
+  test "LiveComponent rendering external template" do
+    assert render_live(View) =~ "the rendered content of the live component"
+  end
+
+  test "LiveView rendering external template" do
+    assert render_live(View) =~ "the rendered content of the live view"
+  end
+end

--- a/test/support/component_with_external_template.sface
+++ b/test/support/component_with_external_template.sface
@@ -1,0 +1,1 @@
+<div>the rendered content of the component</div>

--- a/test/support/live_component_with_external_template.sface
+++ b/test/support/live_component_with_external_template.sface
@@ -1,0 +1,1 @@
+<div>the rendered content of the live component</div>

--- a/test/support/live_view_with_external_template.sface
+++ b/test/support/live_view_with_external_template.sface
@@ -1,0 +1,1 @@
+<div>the rendered content of the live view</div>

--- a/test/support/renderer_test_components.ex
+++ b/test/support/renderer_test_components.ex
@@ -1,0 +1,14 @@
+defmodule Surface.RendererTest.Components do
+  defmodule ComponentWithExternalTemplate do
+    use Surface.Component
+  end
+
+  defmodule LiveComponentWithExternalTemplate do
+    use Surface.LiveComponent
+  end
+
+  defmodule LiveViewWithExternalTemplate do
+    use Surface.LiveView
+  end
+
+end

--- a/test/support/renderer_test_components.ex
+++ b/test/support/renderer_test_components.ex
@@ -10,5 +10,4 @@ defmodule Surface.RendererTest.Components do
   defmodule LiveViewWithExternalTemplate do
     use Surface.LiveView
   end
-
 end


### PR DESCRIPTION
Resolves #22 

I patterned this closely off how live view handles the same functionality, but I couldn't figure out how to write tests for it. It should be somewhat straightforward to add support for stylesheets once we add that functionality.

I added the before compile hooks to the individual types of component instead of BaseComponent because MacroComponent uses BaseComponent as well and I figured that shouldn't have a render function automagically defined.

 I could see adding support for falling back to a `.html.leex`, but haven't added that in. WDYT?