### PR TITLE
[Issue  #113] Check if key __surface__ is present in assigns

### DIFF
--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -86,8 +86,12 @@ defmodule Surface.LiveComponent do
       quote do
         defoverridable update: 2
 
+        def update(%{__surface__: surface} = assigns, socket) do
+          super(assigns, Phoenix.LiveView.assign(socket, :__surface__, surface))
+        end
+
         def update(assigns, socket) do
-          super(assigns, Phoenix.LiveView.assign(socket, :__surface__, assigns.__surface__))
+          super(assigns, socket)
         end
       end
     end


### PR DESCRIPTION
Let me know if I misundestood this issue. But it seems that if assigns change there might not be \__surface__ around the second time.