### PR TITLE
Add bahaviour TypeHandler and implement it for common types

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -139,18 +139,14 @@ defmodule Surface do
     LiveView.assign_new(socket, :__surface__, fn -> %{} end)
   end
 
-  @spec attr_value(any, any) :: any
   @doc false
-  def attr_value(attr, value) do
-    if String.Chars.impl_for(value) do
-      value
-    else
-      IOHelper.runtime_error(
-        "invalid value for attribute \"#{attr}\". Expected a type that implements " <>
-          "the String.Chars protocol (e.g. string, boolean, integer, atom, ...), " <>
-          "got: #{inspect(value)}"
-      )
-    end
+  def attr(name, type, value) do
+    Surface.TypeHandler.attr_to_html(type, name, value)
+  end
+
+  @doc false
+  def expr(name, type, clauses, opts, module, original) do
+    Surface.TypeHandler.expr_to_value(type, name, clauses, opts, module, original)
   end
 
   @doc false
@@ -220,119 +216,6 @@ defmodule Surface do
   end
 
   @doc false
-  def css_class([value]) when is_list(value) do
-    css_class(value)
-  end
-
-  def css_class(value) when is_binary(value) do
-    value
-  end
-
-  def css_class(value) when is_list(value) do
-    Enum.reduce(value, [], fn item, classes ->
-      case item do
-        {class, val} when val not in [nil, false] ->
-          maybe_add_class(classes, class)
-
-        class when is_binary(class) or is_atom(class) ->
-          maybe_add_class(classes, class)
-
-        _ ->
-          classes
-      end
-    end)
-    |> Enum.reverse()
-    |> Enum.join(" ")
-  end
-
-  def css_class(value) do
-    IOHelper.runtime_error(
-      "invalid value for property of type :css_class. " <>
-        "Expected a string or a keyword list, got: #{inspect(value)}"
-    )
-  end
-
-  @doc false
-  def boolean_attr(name, value) do
-    if value do
-      name
-    else
-      ""
-    end
-  end
-
-  @doc false
-  def keyword_value(key, value) do
-    if Keyword.keyword?(value) do
-      value
-    else
-      IOHelper.runtime_error(
-        "invalid value for property \"#{key}\". Expected a :keyword, got: #{inspect(value)}"
-      )
-    end
-  end
-
-  @doc false
-  def map_value(_key, value) when is_map(value) do
-    value
-  end
-
-  def map_value(key, value) do
-    if Keyword.keyword?(value) do
-      Map.new(value)
-    else
-      IOHelper.runtime_error(
-        "invalid value for property \"#{key}\". Expected a :map, got: #{inspect(value)}"
-      )
-    end
-  end
-
-  @doc false
-  def event_value(key, [event], caller_cid) do
-    event_value(key, event, caller_cid)
-  end
-
-  def event_value(key, [name | opts], caller_cid) do
-    event = Map.new(opts) |> Map.put(:name, name)
-    event_value(key, event, caller_cid)
-  end
-
-  def event_value(_key, nil, _caller_cid) do
-    nil
-  end
-
-  def event_value(_key, name, nil) when is_binary(name) do
-    %{name: name, target: :live_view}
-  end
-
-  def event_value(_key, name, caller_cid) when is_binary(name) do
-    %{name: name, target: to_string(caller_cid)}
-  end
-
-  def event_value(_key, %{name: _, target: _} = event, _caller_cid) do
-    event
-  end
-
-  def event_value(key, event, _caller_cid) do
-    IOHelper.runtime_error(
-      "invalid value for event \"#{key}\". Expected an :event or :string, got: #{inspect(event)}"
-    )
-  end
-
-  @doc false
-  def phx_event(_phx_event, value) when is_binary(value) do
-    value
-  end
-
-  def phx_event(phx_event, value) do
-    IOHelper.runtime_error(
-      "invalid value for \"#{phx_event}\". LiveView bindings only accept values " <>
-        "of type :string. If you want to pass an :event, please use directive " <>
-        ":on-#{phx_event} instead. Expected a :string, got: #{inspect(value)}"
-    )
-  end
-
-  @doc false
   def event_to_opts(%{name: name, target: :live_view}, event_name) do
     [{event_name, name}]
   end
@@ -343,16 +226,6 @@ defmodule Surface do
 
   def event_to_opts(nil, _event_name) do
     []
-  end
-
-  defp maybe_add_class(classes, class) do
-    case class |> to_string() |> String.trim() do
-      "" ->
-        classes
-
-      class ->
-        [class | classes]
-    end
   end
 
   defp get_components_config() do

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -76,6 +76,19 @@ defmodule Surface.AST.Meta do
           caller: Macro.Env.t(),
           file: binary()
         }
+
+  def quoted_caller_cid(meta) do
+    cond do
+      Module.open?(meta.caller.module) and
+          Module.get_attribute(meta.caller.module, :component_type) == Surface.LiveComponent ->
+        quote generated: true do
+          @myself
+        end
+
+      true ->
+        nil
+    end
+  end
 end
 
 defmodule Surface.AST.Directive do

--- a/lib/surface/directive/debug.ex
+++ b/lib/surface/directive/debug.ex
@@ -54,7 +54,7 @@ defmodule Surface.Directive.Debug do
 
   defp directive_value(value, meta) do
     expr =
-      case Helpers.attribute_expr_to_quoted!(value, :debug, :bindings, meta) do
+      case Helpers.attribute_expr_to_quoted!(value, ":debug", :bindings, meta) do
         value when is_atom(value) ->
           [value]
 

--- a/lib/surface/directive/for.ex
+++ b/lib/surface/directive/for.ex
@@ -18,7 +18,7 @@ defmodule Surface.Directive.For do
   defp directive_value(value, meta) do
     %AST.AttributeExpr{
       original: value,
-      value: Helpers.attribute_expr_to_quoted!(value, :for, :generator, meta),
+      value: Helpers.attribute_expr_to_quoted!(value, ":for", :generator, meta),
       meta: meta
     }
   end

--- a/lib/surface/directive/if.ex
+++ b/lib/surface/directive/if.ex
@@ -18,7 +18,7 @@ defmodule Surface.Directive.If do
   defp directive_value(value, meta) do
     %AST.AttributeExpr{
       original: value,
-      value: Helpers.attribute_expr_to_quoted!(value, :if, :boolean, meta),
+      value: Helpers.attribute_expr_to_quoted!(value, ":if", :boolean, meta),
       meta: meta
     }
   end

--- a/lib/surface/directive/let.ex
+++ b/lib/surface/directive/let.ex
@@ -15,7 +15,7 @@ defmodule Surface.Directive.Let do
   defp directive_value(value, meta) do
     # using a list here because it doesn't wrap the result in a function call
     # to Surface.<type>_value(...)
-    expr = Helpers.attribute_expr_to_quoted!(value, :let, :bindings, meta)
+    expr = Helpers.attribute_expr_to_quoted!(value, ":let:", :bindings, meta)
 
     if !Keyword.keyword?(expr) do
       invalid_let_binding(value, meta)

--- a/lib/surface/directive/show.ex
+++ b/lib/surface/directive/show.ex
@@ -65,7 +65,7 @@ defmodule Surface.Directive.Show do
   end
 
   defp directive_value(value, meta) do
-    expr = Helpers.attribute_expr_to_quoted!(value, :show, :boolean, meta)
+    expr = Helpers.attribute_expr_to_quoted!(value, ":show", :boolean, meta)
 
     expr =
       quote generated: true do

--- a/lib/surface/directive/slot_props.ex
+++ b/lib/surface/directive/slot_props.ex
@@ -13,7 +13,7 @@ defmodule Surface.Directive.SlotProps do
   def extract(_, _), do: []
 
   defp directive_value(value, meta) do
-    expr = Helpers.attribute_expr_to_quoted!(value, :props, :bindings, meta)
+    expr = Helpers.attribute_expr_to_quoted!(value, ":props", :bindings, meta)
 
     if !Keyword.keyword?(expr) do
       message = """

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -1,0 +1,99 @@
+defmodule Surface.TypeHandler do
+  @moduledoc false
+
+  alias Surface.IOHelper
+
+  # TODO: [Type] Validate the expression at compile-time if possible, e.g. literals, typed assigns
+  # @callback validate_expr(clauses :: [Macro.t()], opts :: keyword(Macro.t())) :: {:ok, clauses, opts} | :error | {:error, message}
+
+  @callback expr_to_value(clauses :: list(), opts :: keyword()) :: any()
+
+  @callback value_to_html(name :: atom(), value :: any()) :: String.t()
+
+  @callback update_prop_expr(expr :: Macro.t(), meta :: Surface.AST.Meta.t()) :: Macro.t()
+
+  @optional_callbacks [expr_to_value: 2, value_to_html: 2, update_prop_expr: 2]
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour unquote(__MODULE__)
+      @default_handler unquote(__MODULE__).Default
+
+      defdelegate expr_to_value(clauses, opts), to: @default_handler
+      defdelegate value_to_html(name, value), to: @default_handler
+      defdelegate update_prop_expr(expr, meta), to: @default_handler
+
+      defoverridable unquote(__MODULE__)
+    end
+  end
+
+  def expr_to_value(type, name, clauses, opts, module, original) do
+    case handler(type).expr_to_value(clauses, opts) do
+      {:ok, value} ->
+        value
+
+      {:error, value} ->
+        message = error_message(type, name, value, module, original)
+        IOHelper.runtime_error(message)
+
+      {:error, value, details} ->
+        message = error_message(type, name, value, module, original, details)
+        IOHelper.runtime_error(message)
+    end
+  end
+
+  def attr_to_html(:boolean, name, value) do
+    if value do
+      [~S( ), to_string(name)]
+    else
+      ""
+    end
+  end
+
+  def attr_to_html(type, name, value) do
+    case handler(type).value_to_html(name, value) do
+      string when string in ["", nil] ->
+        ""
+
+      string ->
+        Phoenix.HTML.raw([" ", to_string(name), "=", ~S("), string, ~S(")])
+    end
+  end
+
+  def update_prop_expr(type, value, meta) do
+    handler(type).update_prop_expr(value, meta)
+  end
+
+  defp handler(:boolean), do: __MODULE__.Boolean
+  defp handler(:map), do: __MODULE__.Map
+  defp handler(:keyword), do: __MODULE__.Keyword
+  defp handler(:css_class), do: __MODULE__.CssClass
+  defp handler(:event), do: __MODULE__.Event
+  defp handler(:phx_event), do: __MODULE__.PhxEvent
+  defp handler(_), do: __MODULE__.Default
+
+  defp error_message(type, name, value, module, original, details \\ nil) do
+    details = if details, do: "\n" <> details, else: details
+
+    """
+    invalid value for #{get_attr_type(name, module)} "#{name}". \
+    Expected a #{inspect(type)}, got: #{inspect(value)}.
+
+    Original expression: {{#{original}}}
+    #{details}\
+    """
+  end
+
+  defp get_attr_type(name, module) do
+    cond do
+      to_string(name) |> String.starts_with?(":") ->
+        "directive"
+
+      module ->
+        "property"
+
+      true ->
+        "attribute"
+    end
+  end
+end

--- a/lib/surface/type_handler/boolean.ex
+++ b/lib/surface/type_handler/boolean.ex
@@ -1,0 +1,10 @@
+defmodule Surface.TypeHandler.Boolean do
+  @moduledoc false
+
+  use Surface.TypeHandler
+
+  @impl true
+  def expr_to_value([value], []) do
+    {:ok, !!value}
+  end
+end

--- a/lib/surface/type_handler/css_class.ex
+++ b/lib/surface/type_handler/css_class.ex
@@ -1,0 +1,44 @@
+defmodule Surface.TypeHandler.CssClass do
+  @moduledoc false
+
+  use Surface.TypeHandler
+
+  @impl true
+  def expr_to_value([value], opts) when is_list(value) do
+    expr_to_value(value, opts)
+  end
+
+  def expr_to_value(clauses, opts) do
+    value =
+      Enum.reduce(clauses ++ opts, [], fn item, classes ->
+        case item do
+          {class, val} when val not in [nil, false] ->
+            maybe_add_class(classes, class)
+
+          class when is_binary(class) or is_atom(class) ->
+            maybe_add_class(classes, class)
+
+          _ ->
+            classes
+        end
+      end)
+      |> Enum.reverse()
+
+    {:ok, value}
+  end
+
+  @impl true
+  def value_to_html(_name, value) do
+    Enum.join(value, " ")
+  end
+
+  defp maybe_add_class(classes, class) do
+    new_classes =
+      class
+      |> to_string()
+      |> String.split(" ", trim: true)
+      |> Enum.reverse()
+
+    new_classes ++ classes
+  end
+end

--- a/lib/surface/type_handler/default.ex
+++ b/lib/surface/type_handler/default.ex
@@ -1,0 +1,34 @@
+defmodule Surface.TypeHandler.Default do
+  @moduledoc false
+
+  use Surface.TypeHandler
+
+  alias Surface.IOHelper
+
+  @impl true
+  def expr_to_value([value], []) do
+    {:ok, value}
+  end
+
+  def expr_to_value(clauses, opts) do
+    {:error, clauses ++ opts}
+  end
+
+  @impl true
+  def value_to_html(name, value) do
+    if String.Chars.impl_for(value) do
+      value
+    else
+      IOHelper.runtime_error(
+        "invalid value for attribute \"#{name}\". Expected a type that implements " <>
+          "the String.Chars protocol (e.g. string, boolean, integer, atom, ...), " <>
+          "got: #{inspect(value)}"
+      )
+    end
+  end
+
+  @impl true
+  def update_prop_expr(value, _meta) do
+    value
+  end
+end

--- a/lib/surface/type_handler/event.ex
+++ b/lib/surface/type_handler/event.ex
@@ -1,0 +1,48 @@
+defmodule Surface.TypeHandler.Event do
+  @moduledoc false
+
+  use Surface.TypeHandler
+
+  @impl true
+  def expr_to_value([nil], []) do
+    {:ok, nil}
+  end
+
+  def expr_to_value([%{name: _, target: _} = event], []) do
+    {:ok, event}
+  end
+
+  def expr_to_value([[name, {:target, target}]], [])
+      when is_binary(name) and (is_binary(target) or is_atom(target)) do
+    {:ok, %{name: name, target: target}}
+  end
+
+  def expr_to_value([name], opts) when is_atom(name) or is_binary(name) do
+    {:ok, %{name: name, target: Keyword.get(opts, :target)}}
+  end
+
+  def expr_to_value(clauses, opts) do
+    {:error, {clauses, opts}}
+  end
+
+  @impl true
+  def update_prop_expr(value, meta) do
+    caller_cid = Surface.AST.Meta.quoted_caller_cid(meta)
+
+    quote generated: true do
+      unquote(__MODULE__).maybe_update_target(unquote(value), unquote(caller_cid))
+    end
+  end
+
+  def maybe_update_target(%{target: nil} = event, nil) do
+    %{event | target: :live_view}
+  end
+
+  def maybe_update_target(%{target: nil} = event, cid) do
+    %{event | target: cid}
+  end
+
+  def maybe_update_target(event, _cid) do
+    event
+  end
+end

--- a/lib/surface/type_handler/keyword.ex
+++ b/lib/surface/type_handler/keyword.ex
@@ -1,0 +1,22 @@
+defmodule Surface.TypeHandler.Keyword do
+  @moduledoc false
+
+  use Surface.TypeHandler
+
+  @impl true
+  def expr_to_value([value], []) do
+    if is_list(value) and Keyword.keyword?(value) do
+      {:ok, value}
+    else
+      {:error, value}
+    end
+  end
+
+  def expr_to_value([], opts) do
+    {:ok, opts}
+  end
+
+  def expr_to_value(clauses, opts) do
+    {:error, clauses ++ opts}
+  end
+end

--- a/lib/surface/type_handler/map.ex
+++ b/lib/surface/type_handler/map.ex
@@ -1,0 +1,27 @@
+defmodule Surface.TypeHandler.Map do
+  @moduledoc false
+
+  use Surface.TypeHandler
+
+  @impl true
+  def expr_to_value([value], []) do
+    cond do
+      is_map(value) ->
+        {:ok, value}
+
+      is_list(value) and Keyword.keyword?(value) ->
+        {:ok, Map.new(value)}
+
+      true ->
+        {:error, value}
+    end
+  end
+
+  def expr_to_value([], opts) do
+    {:ok, Map.new(opts)}
+  end
+
+  def expr_to_value(clauses, opts) do
+    {:error, clauses ++ opts}
+  end
+end

--- a/lib/surface/type_handler/phx_event.ex
+++ b/lib/surface/type_handler/phx_event.ex
@@ -1,0 +1,20 @@
+defmodule Surface.TypeHandler.PhxEvent do
+  @moduledoc false
+
+  use Surface.TypeHandler
+
+  alias Surface.IOHelper
+
+  @impl true
+  def value_to_html(_name, value) when is_binary(value) or is_nil(value) do
+    value
+  end
+
+  def value_to_html(name, value) do
+    IOHelper.runtime_error(
+      "invalid value for \"#{name}\". LiveView bindings only accept values " <>
+        "of type :string. If you want to pass an :event, please use directive " <>
+        ":on-#{name} instead. Expected a :string, got: #{inspect(value)}"
+    )
+  end
+end

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -104,7 +104,7 @@ defmodule Surface.CompilerTest do
                  value: [
                    %Surface.AST.AttributeExpr{
                      original: " @label ",
-                     value: {:@, _, [{:label, _, _}]}
+                     value: {_, _, [_, _, [{:@, _, [{:label, _, _}]}], [], _, _]}
                    }
                  ]
                }
@@ -129,12 +129,21 @@ defmodule Surface.CompilerTest do
                    %Surface.AST.Text{value: "str_1 "},
                    %Surface.AST.AttributeExpr{
                      original: "@str_2",
-                     value: {:@, _, [{:str_2, _, _}]}
+                     value: {_, _, [_, _, [{:@, _, [{:str_2, _, _}]}], [], _, _]}
                    },
                    %Surface.AST.Text{value: " str_3 "},
                    %Surface.AST.AttributeExpr{
                      original: "@str_4 <> @str_5",
-                     value: {:<>, _, [{:@, _, [{:str_4, _, _}]}, {:@, _, [{:str_5, _, _}]}]}
+                     value:
+                       {_, _,
+                        [
+                          _,
+                          _,
+                          [{:<>, _, [{:@, _, [{:str_4, _, _}]}, {:@, _, [{:str_5, _, _}]}]}],
+                          [],
+                          _,
+                          _
+                        ]}
                    }
                  ]
                }
@@ -157,9 +166,7 @@ defmodule Surface.CompilerTest do
                  type: :event,
                  value: [
                    %Surface.AST.AttributeExpr{
-                     value:
-                       {{:., _, [{:__aliases__, _, [:Surface]}, :event_value]}, _,
-                        [:click, ["click_event"], nil]},
+                     value: _,
                      original: "click_event"
                    }
                  ]
@@ -240,9 +247,7 @@ defmodule Surface.CompilerTest do
                  type: :event,
                  value: [
                    %Surface.AST.AttributeExpr{
-                     value:
-                       {{:., _, [{:__aliases__, _, [:Surface]}, :event_value]}, _,
-                        [:click, ["event"], nil]},
+                     value: _expr,
                      original: "event"
                    }
                  ]
@@ -281,9 +286,7 @@ defmodule Surface.CompilerTest do
                  type: :event,
                  value: [
                    %Surface.AST.AttributeExpr{
-                     value:
-                       {{:., _, [{:__aliases__, _, [:Surface]}, :event_value]}, _,
-                        [:click, ["event"], nil]},
+                     value: _expr,
                      original: "event"
                    }
                  ]
@@ -345,8 +348,7 @@ defmodule Surface.CompilerTest do
                  name: :"phx-click",
                  expr: %Surface.AST.AttributeExpr{
                    original: "",
-                   # validating that the empty string is treated the same as `nil`
-                   value: {:case, _, [nil, _]}
+                   value: _
                  }
                },
                %Surface.AST.Attribute{
@@ -391,9 +393,7 @@ defmodule Surface.CompilerTest do
                  value: [
                    %Surface.AST.AttributeExpr{
                      original: " %{user_id: 1} ",
-                     value:
-                       {{:., _, [{:__aliases__, _, [:Surface]}, :map_value]}, _,
-                        [:session, {:%{}, _, [user_id: 1]}]}
+                     value: _
                    }
                  ]
                }

--- a/test/components/field_test.exs
+++ b/test/components/field_test.exs
@@ -13,7 +13,7 @@ defmodule Surface.Components.FieldTest do
     """
 
     assert render_live(code) =~ """
-           <div class="">
+           <div>
              Hi
            </div>
            """

--- a/test/components/link_test.exs
+++ b/test/components/link_test.exs
@@ -11,7 +11,7 @@ defmodule Surface.Components.LinkTest do
     def render(assigns) do
       ~H"""
       <div>
-        <Link to="/users/1" click="my_click" />
+        <Link to="/users/1" click="my_click"/>
       </div>
       """
     end

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -210,6 +210,18 @@ defmodule HtmlTagTest do
              <div class="Default Prop1"></div>
              """
     end
+
+    test "don't render attribute if value is nil" do
+      assigns = %{value1: nil}
+
+      code = ~H"""
+      <div class={{ @value1 }}/>
+      """
+
+      assert render_static(code) =~ """
+             <div></div>
+             """
+    end
   end
 
   test "boolean attributes" do

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -55,6 +55,18 @@ defmodule Surface.PropertiesTest do
     end
   end
 
+  defmodule CSSClassPropInspect do
+    use Surface.Component
+
+    property prop, :css_class
+
+    def render(assigns) do
+      ~H"""
+      <div :for={{ c <- @prop }}>{{ c }}</div>
+      """
+    end
+  end
+
   describe "keyword" do
     test "passing a keyword list" do
       code = """
@@ -95,14 +107,20 @@ defmodule Surface.PropertiesTest do
     end
 
     test "validate invalid values" do
+      assigns = %{var: 1}
+
       code = """
-      <KeywordProp prop={{ 1 }}/>
+      <KeywordProp prop={{ @var }}/>
       """
 
-      message = "invalid value for property \"prop\". Expected a :keyword, got: 1"
+      message = """
+      invalid value for property "prop". Expected a :keyword, got: 1.
+
+      Original expression: {{ @var }}
+      """
 
       assert_raise(RuntimeError, message, fn ->
-        render_live(code)
+        render_live(code, assigns)
       end)
     end
   end
@@ -173,14 +191,20 @@ defmodule Surface.PropertiesTest do
     end
 
     test "validate invalid values" do
+      assigns = %{var: 1}
+
       code = """
-      <MapProp prop={{ 1 }}/>
+      <MapProp prop={{ @var }}/>
       """
 
-      message = "invalid value for property \"prop\". Expected a :map, got: 1"
+      message = """
+      invalid value for property "prop". Expected a :map, got: 1.
+
+      Original expression: {{ @var }}
+      """
 
       assert_raise(RuntimeError, message, fn ->
-        render_live(code)
+        render_live(code, assigns)
       end)
     end
   end
@@ -300,6 +324,24 @@ defmodule Surface.PropertiesTest do
 
       assert render_live(code) =~ """
              <span class="class1 class2 class3"></span>
+             """
+    end
+
+    test "values are always converted to a list of strings" do
+      code = """
+      <CSSClassPropInspect prop="class1 class2   class3"/>
+      """
+
+      assert render_live(code) =~ """
+             <div>class1</div><div>class2</div><div>class3</div>
+             """
+
+      code = """
+      <CSSClassPropInspect prop={{ ["class1"] ++ ["class2 class3", :class4, class5: true] }}/>
+      """
+
+      assert render_live(code) =~ """
+             <div>class1</div><div>class2</div><div>class3</div><div>class4</div><div>class5</div>
              """
     end
   end


### PR DESCRIPTION
@lnr0626 this PR tries to move any code that depends on a specific type to a single handler. Currently (and certainly before the compiler), this logic is spread through the whole codebase which makes maintaining the code much harder. 

The PR also makes the values of properties and attributes consistent as they are all normalized before we start to manipulate them. 

Expressions can now be also normalized before we use them so we don't have to add hacks for each type like wrapping the values in `[...]` or `identity(...)` anymore. All expressions should be normalized to lists of `clauses` + `opts`, if it doesn't, there's a syntax error. Then each type handler knows how to convert that information into the actual value. This provides a consistent way to add syntactic sugar for types like `css_class`, `:event`, `map`, `keyword`, etc.

There is still some code to migrate to the new handlers but I believe we're almost there. I think it's better to create the PR already so we can discuss improvements before merging it. I also added a few `# TODO: [Type]` indicating some points in the code that either still needs to be migrated or is marked for discussion.

Please, feel free to add suggestions, comments or event implement some of the TODOs, if you want :)