### PR TITLE
New directives: `:props` for components and `:attrs` for tags

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -140,6 +140,11 @@ defmodule Surface do
   end
 
   @doc false
+  def default_props(module) do
+    Enum.map(module.__props__(), fn %{name: name, opts: opts} -> {name, opts[:default]} end)
+  end
+
+  @doc false
   def build_assigns(
         context,
         static_props,
@@ -149,9 +154,6 @@ defmodule Surface do
         module,
         node_alias
       ) do
-    prop_defaults =
-      Enum.map(module.__props__(), fn %{name: name, opts: opts} -> {name, opts[:default]} end)
-
     static_prop_names = Keyword.keys(static_props)
 
     dynamic_props =
@@ -161,7 +163,7 @@ defmodule Surface do
         {name, Surface.TypeHandler.runtime_prop_value!(module, name, value, node_alias || module)}
       end)
 
-    props = Keyword.merge(Keyword.merge(prop_defaults, dynamic_props), static_props)
+    props = Keyword.merge(Keyword.merge(default_props(module), dynamic_props), static_props)
 
     gets_from_context =
       module

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -359,13 +359,14 @@ defmodule Surface.AST.Component do
       * `:meta` - compilation meta data
       * `:debug` - keyword list indicating when debug information should be printed during compilation
   """
-  defstruct [:module, :type, :props, :directives, :templates, :meta, debug: []]
+  defstruct [:module, :type, :props, :dynamic_props, :directives, :templates, :meta, debug: []]
 
   @type t :: %__MODULE__{
           module: module(),
           debug: List.t(atom()),
           type: module(),
           props: list(Surface.AST.Attribute.t()),
+          dynamic_props: Surface.AST.DynamicAttribute.t(),
           directives: list(Surface.AST.Directive.t()),
           templates: %{
             :default => list(Surface.AST.Template.t() | Surface.AST.SlotableComponent.t()),
@@ -390,7 +391,18 @@ defmodule Surface.AST.SlotableComponent do
       * `:meta` - compilation meta data
       * `:debug` - keyword list indicating when debug information should be printed during compilation
   """
-  defstruct [:module, :slot, :type, :let, :props, :directives, :templates, :meta, debug: []]
+  defstruct [
+    :module,
+    :slot,
+    :type,
+    :let,
+    :props,
+    :dynamic_props,
+    :directives,
+    :templates,
+    :meta,
+    debug: []
+  ]
 
   @type t :: %__MODULE__{
           module: module(),
@@ -399,6 +411,7 @@ defmodule Surface.AST.SlotableComponent do
           slot: atom(),
           let: Surface.AST.Directive.t(),
           props: list(Surface.AST.Attribute.t()),
+          dynamic_props: Surface.AST.DynamicAttribute.t(),
           directives: list(Surface.AST.Directive.t()),
           templates: %{
             :default => list(Surface.AST.Template.t()),

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -15,7 +15,7 @@ defmodule Surface.Compiler do
   ]
 
   @tag_directive_handlers [
-    Surface.Directive.TagProps,
+    Surface.Directive.TagAttrs,
     Surface.Directive.Events,
     Surface.Directive.Show,
     Surface.Directive.If,

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -15,6 +15,7 @@ defmodule Surface.Compiler do
   ]
 
   @tag_directive_handlers [
+    Surface.Directive.TagProps,
     Surface.Directive.Events,
     Surface.Directive.Show,
     Surface.Directive.If,

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -24,6 +24,7 @@ defmodule Surface.Compiler do
   ]
 
   @component_directive_handlers [
+    Surface.Directive.ComponentProps,
     Surface.Directive.If,
     Surface.Directive.For,
     Surface.Directive.Debug

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -241,7 +241,6 @@ defmodule Surface.Compiler.EExEngine do
   defp handle_dynamic_props(nil), do: []
 
   defp handle_dynamic_props(%AST.DynamicAttribute{expr: %AST.AttributeExpr{value: expr}}) do
-    # TODO: how much processing should we actually do on these values?
     quote generated: true do
       for {name, {type, value}} <- unquote(expr) do
         {name, value}

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -367,8 +367,11 @@ defmodule Surface.Compiler.EExEngine do
         [%AST.Template{children: children}] -> children
       end
 
+    props = collect_component_props(module, props)
+    default_props = Surface.default_props(module)
+
     [
-      {add_default_bindings(component, name, let), collect_component_props(module, props),
+      {add_default_bindings(component, name, let), Keyword.merge(default_props, props),
        handle_nested_block(template, buffer, %{state | depth: state.depth + 1})}
       | handle_templates(component, tail, buffer, state)
     ]

--- a/lib/surface/directive/component_props.ex
+++ b/lib/surface/directive/component_props.ex
@@ -1,0 +1,60 @@
+defmodule Surface.Directive.ComponentProps do
+  use Surface.Directive
+
+  def extract({":props", {:attribute_expr, value, expr_meta}, attr_meta}, meta) do
+    expr_meta = Helpers.to_meta(expr_meta, meta)
+    attr_meta = Helpers.to_meta(attr_meta, meta)
+
+    %AST.Directive{
+      module: __MODULE__,
+      name: :props,
+      value: directive_value(value, expr_meta),
+      meta: attr_meta
+    }
+  end
+
+  def extract(_, _), do: []
+
+  def process(
+        %AST.Directive{value: %AST.AttributeExpr{value: value} = expr, meta: meta},
+        %AST.Component{module: module, props: props} = node
+      ) do
+    static_prop_names =
+      props
+      |> Enum.filter(fn
+        %AST.Attribute{} -> true
+        _ -> false
+      end)
+      |> Enum.map(fn %AST.Attribute{name: name} -> name end)
+
+    new_expr =
+      quote generated: true do
+        for {name, value} <- unquote(value) || [],
+            not Enum.member?(unquote(Macro.escape(static_prop_names)), name) do
+          {name,
+           {Surface.TypeHandler.attribute_type(
+              unquote(module),
+              name,
+              unquote(Macro.escape(meta))
+            ), value}}
+        end
+      end
+
+    %{
+      node
+      | dynamic_props: %AST.DynamicAttribute{
+          name: :props,
+          meta: meta,
+          expr: %{expr | value: new_expr}
+        }
+    }
+  end
+
+  defp directive_value(value, meta) do
+    %AST.AttributeExpr{
+      original: value,
+      value: Surface.TypeHandler.expr_to_quoted!(value, ":props", :map, meta),
+      meta: meta
+    }
+  end
+end

--- a/lib/surface/directive/component_props.ex
+++ b/lib/surface/directive/component_props.ex
@@ -31,12 +31,7 @@ defmodule Surface.Directive.ComponentProps do
       quote generated: true do
         for {name, value} <- unquote(value) || [],
             not Enum.member?(unquote(Macro.escape(static_prop_names)), name) do
-          {name,
-           {Surface.TypeHandler.attribute_type(
-              unquote(module),
-              name,
-              unquote(Macro.escape(meta))
-            ), value}}
+          {name, Surface.TypeHandler.runtime_prop_value!(unquote(module), name, value, unquote(meta.node_alias))}
         end
       end
 

--- a/lib/surface/directive/component_props.ex
+++ b/lib/surface/directive/component_props.ex
@@ -16,37 +16,15 @@ defmodule Surface.Directive.ComponentProps do
   def extract(_, _), do: []
 
   def process(
-        %AST.Directive{value: %AST.AttributeExpr{value: value} = expr, meta: meta},
-        %AST.Component{module: module, props: props} = node
+        %AST.Directive{value: %AST.AttributeExpr{} = expr, meta: meta},
+        %AST.Component{} = node
       ) do
-    static_prop_names =
-      props
-      |> Enum.filter(fn
-        %AST.Attribute{} -> true
-        _ -> false
-      end)
-      |> Enum.map(fn %AST.Attribute{name: name} -> name end)
-
-    new_expr =
-      quote generated: true do
-        for {name, value} <- unquote(value) || [],
-            not Enum.member?(unquote(Macro.escape(static_prop_names)), name) do
-          {name,
-           Surface.TypeHandler.runtime_prop_value!(
-             unquote(module),
-             name,
-             value,
-             unquote(meta.node_alias)
-           )}
-        end
-      end
-
     %{
       node
       | dynamic_props: %AST.DynamicAttribute{
           name: :props,
           meta: meta,
-          expr: %{expr | value: new_expr}
+          expr: expr
         }
     }
   end

--- a/lib/surface/directive/component_props.ex
+++ b/lib/surface/directive/component_props.ex
@@ -31,7 +31,13 @@ defmodule Surface.Directive.ComponentProps do
       quote generated: true do
         for {name, value} <- unquote(value) || [],
             not Enum.member?(unquote(Macro.escape(static_prop_names)), name) do
-          {name, Surface.TypeHandler.runtime_prop_value!(unquote(module), name, value, unquote(meta.node_alias))}
+          {name,
+           Surface.TypeHandler.runtime_prop_value!(
+             unquote(module),
+             name,
+             value,
+             unquote(meta.node_alias)
+           )}
         end
       end
 

--- a/lib/surface/directive/tag_attrs.ex
+++ b/lib/surface/directive/tag_attrs.ex
@@ -1,13 +1,13 @@
-defmodule Surface.Directive.TagProps do
+defmodule Surface.Directive.TagAttrs do
   use Surface.Directive
 
-  def extract({":props", {:attribute_expr, value, expr_meta}, attr_meta}, meta) do
+  def extract({":attrs", {:attribute_expr, value, expr_meta}, attr_meta}, meta) do
     expr_meta = Helpers.to_meta(expr_meta, meta)
     attr_meta = Helpers.to_meta(attr_meta, meta)
 
     %AST.Directive{
       module: __MODULE__,
-      name: :props,
+      name: :attrs,
       value: directive_value(value, expr_meta),
       meta: attr_meta
     }
@@ -39,7 +39,7 @@ defmodule Surface.Directive.TagProps do
     %{
       node
       | attributes: [
-          %AST.DynamicAttribute{name: :props, meta: meta, expr: %{expr | value: new_expr}}
+          %AST.DynamicAttribute{name: :attrs, meta: meta, expr: %{expr | value: new_expr}}
           | attributes
         ]
     }
@@ -48,7 +48,7 @@ defmodule Surface.Directive.TagProps do
   defp directive_value(value, meta) do
     %AST.AttributeExpr{
       original: value,
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":props", :map, meta),
+      value: Surface.TypeHandler.expr_to_quoted!(value, ":attrs", :map, meta),
       meta: meta
     }
   end

--- a/lib/surface/directive/tag_props.ex
+++ b/lib/surface/directive/tag_props.ex
@@ -1,0 +1,55 @@
+defmodule Surface.Directive.TagProps do
+  use Surface.Directive
+
+  def extract({":props", {:attribute_expr, value, expr_meta}, attr_meta}, meta) do
+    expr_meta = Helpers.to_meta(expr_meta, meta)
+    attr_meta = Helpers.to_meta(attr_meta, meta)
+
+    %AST.Directive{
+      module: __MODULE__,
+      name: :props,
+      value: directive_value(value, expr_meta),
+      meta: attr_meta
+    }
+  end
+
+  def extract(_, _), do: []
+
+  def process(
+        %AST.Directive{value: %AST.AttributeExpr{value: value} = expr, meta: meta},
+        %type{attributes: attributes} = node
+      )
+      when type in [AST.Tag, AST.VoidTag] do
+    attr_names =
+      attributes
+      |> Enum.filter(fn
+        %AST.Attribute{} -> true
+        _ -> false
+      end)
+      |> Enum.map(fn %AST.Attribute{name: name} -> name end)
+
+    new_expr =
+      quote generated: true do
+        for {name, value} <- unquote(value) || [],
+            not Enum.member?(unquote(Macro.escape(attr_names)), name) do
+          {name, {Surface.TypeHandler.attribute_type(name), value}}
+        end
+      end
+
+    %{
+      node
+      | attributes: [
+          %AST.DynamicAttribute{name: :props, meta: meta, expr: %{expr | value: new_expr}}
+          | attributes
+        ]
+    }
+  end
+
+  defp directive_value(value, meta) do
+    %AST.AttributeExpr{
+      original: value,
+      value: Surface.TypeHandler.expr_to_quoted!(value, ":props", :map, meta),
+      meta: meta
+    }
+  end
+end

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -167,6 +167,17 @@ defmodule Surface.TypeHandler do
     handler(type).update_prop_expr(value, meta)
   end
 
+  def runtime_prop_value!(module, name, value, node_alias) do
+    type =
+      attribute_type(module, name, %{
+        node_alias: node_alias || module,
+        caller: __ENV__,
+        line: __ENV__.line
+      })
+
+    {type, expr_to_value!(type, name, [value], [], module, value)}
+  end
+
   def attribute_type(name) do
     attribute_type(nil, name, nil)
   end

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -175,7 +175,7 @@ defmodule Surface.TypeHandler do
         line: __ENV__.line
       })
 
-    {type, expr_to_value!(type, name, [value], [], module, value)}
+    expr_to_value!(type, name, [value], [], module, value)
   end
 
   def attribute_type(name) do

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -14,6 +14,66 @@ defmodule Surface.DirectivesTest do
     end
   end
 
+  defmodule DivWithProps do
+    use Surface.Component
+
+    property(class, :string)
+    property(hidden, :boolean)
+    property(content, :string)
+
+    def render(assigns) do
+      ~H"""
+      <div class={{ @class, hidden: @hidden, block: !@hidden }}>
+        {{ @content }}
+      </div>
+      """
+    end
+  end
+
+  describe ":props for a component" do
+    test "passing keyword list of props" do
+      assigns = %{}
+
+      code = """
+      <DivWithProps :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
+      """
+
+      assert render_live(code, assigns) =~ """
+             <div class="text-xs block">
+               dynamic props content
+             </div>
+             """
+    end
+
+    test "static props override dynamic props" do
+      assigns = %{}
+
+      code = """
+      <DivWithProps content="static content" :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
+      """
+
+      assert render_live(code, assigns) =~ """
+             <div class="text-xs block">
+               static content
+             </div>
+             """
+    end
+
+    test "using an assign" do
+      assigns = %{opts: %{class: "text-xs", hidden: false, content: "dynamic props content"}}
+
+      code = """
+      <DivWithProps :props={{ @opts }} />
+      """
+
+      assert render_live(code, assigns) =~ """
+             <div class="text-xs block">
+               dynamic props content
+             </div>
+             """
+    end
+  end
+
   describe ":attrs in html tags" do
     test "passing a keyword list" do
       assigns = %{}

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -14,6 +14,88 @@ defmodule Surface.DirectivesTest do
     end
   end
 
+  describe ":props in html tags" do
+    test "passing a keyword list" do
+      assigns = %{}
+
+      code = ~H"""
+      <div class="myclass" :props={{ id: "myid" }}>
+        Some Text
+      </div>
+      """
+
+      assert render_static(code) =~ """
+             <div id="myid" class="myclass">
+               Some Text
+             </div>
+             """
+    end
+
+    test "passing a map" do
+      assigns = %{}
+
+      code = ~H"""
+      <div class="myclass" :props={{ %{id: "myid"} }}>
+        Some Text
+      </div>
+      """
+
+      assert render_static(code) =~ """
+             <div id="myid" class="myclass">
+               Some Text
+             </div>
+             """
+    end
+
+    test "using an assign" do
+      assigns = %{div_props: [id: "myid", "aria-label": "A div"]}
+
+      code = ~H"""
+      <div class="myclass" :props={{ @div_props }}>
+        Some Text
+      </div>
+      """
+
+      assert render_static(code) =~ """
+             <div aria-label="A div" id="myid" class="myclass">
+               Some Text
+             </div>
+             """
+    end
+
+    test "with boolean properties" do
+      assigns = %{}
+
+      code = ~H"""
+      <div class="myclass" :props={{ disabled: true }}>
+        Some Text
+      </div>
+      """
+
+      assert render_static(code) =~ """
+             <div disabled class="myclass">
+               Some Text
+             </div>
+             """
+    end
+
+    test "static properties override dyanmic properties" do
+      assigns = %{}
+
+      code = ~H"""
+      <div class="myclass" id="static-id" :props={{ id: "dynamic-id" }}>
+        Some Text
+      </div>
+      """
+
+      assert render_static(code) =~ """
+             <div class="myclass" id="static-id">
+               Some Text
+             </div>
+             """
+    end
+  end
+
   describe ":for" do
     test "in components" do
       assigns = %{items: [1, 2]}

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -14,12 +14,12 @@ defmodule Surface.DirectivesTest do
     end
   end
 
-  describe ":props in html tags" do
+  describe ":attrs in html tags" do
     test "passing a keyword list" do
       assigns = %{}
 
       code = ~H"""
-      <div class="myclass" :props={{ id: "myid" }}>
+      <div class="myclass" :attrs={{ id: "myid" }}>
         Some Text
       </div>
       """
@@ -35,7 +35,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{}
 
       code = ~H"""
-      <div class="myclass" :props={{ %{id: "myid"} }}>
+      <div class="myclass" :attrs={{ %{id: "myid"} }}>
         Some Text
       </div>
       """
@@ -51,7 +51,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{div_props: [id: "myid", "aria-label": "A div"]}
 
       code = ~H"""
-      <div class="myclass" :props={{ @div_props }}>
+      <div class="myclass" :attrs={{ @div_props }}>
         Some Text
       </div>
       """
@@ -67,7 +67,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{}
 
       code = ~H"""
-      <div class="myclass" :props={{ disabled: true }}>
+      <div class="myclass" :attrs={{ disabled: true }}>
         Some Text
       </div>
       """
@@ -83,7 +83,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{}
 
       code = ~H"""
-      <div class="myclass" id="static-id" :props={{ id: "dynamic-id" }}>
+      <div class="myclass" id="static-id" :attrs={{ id: "dynamic-id" }}>
         Some Text
       </div>
       """

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -141,6 +141,14 @@ defmodule Surface.SlotTest do
     def render(assigns), do: ~H()
   end
 
+  defmodule ColumnWithDefaultTitle do
+    use Surface.Component, slot: "cols"
+
+    property title, :string, default: "default title"
+
+    def render(assigns), do: ~H()
+  end
+
   defmodule Grid do
     use Surface.LiveComponent
 
@@ -317,6 +325,32 @@ defmodule Surface.SlotTest do
         Default fallback
         Footer fallback
       </div>
+      """
+    )
+  end
+
+  test "slottable component with default value for prop" do
+    assigns = %{items: [%{id: 1, name: "First"}, %{id: 2, name: "Second"}]}
+
+    code = """
+    <Grid items={{ user <- @items }}>
+      <ColumnWithDefaultTitle>
+        <b>Id: {{ user.id }}</b>
+      </ColumnWithDefaultTitle>
+    </Grid>
+    """
+
+    assert_html(
+      render_live(code, assigns) =~ """
+      <table>
+        <tr>
+          <th>default title</th>
+        </tr><tr>
+          <td><b>Id: 1</b></td>
+        </tr><tr>
+          <td><b>Id: 2</b></td>
+        </tr>
+      </table>
       """
     )
   end


### PR DESCRIPTION
These have similar capabilities. `:props` allows providing a map of props to a component which is evaluated at runtime, `:attrs` allows providing a map of attributes for html tags which are evaluated at run time. For both of these, if a prop/attribute of the same name has a value explicitly provided, that will override any dynamic/runtime values provided via `:props`/`:attrs`.

It's a slightly different approach from the current pr
- the props are added as normal props instead of via a `__dynamic_props__` map
- the attributes have to be explicitly passed to the tag (either via `:attrs` or by specifying the attribute explicitly)
- props which aren't specified in the component will emit a runtime warning

As is, I think the remaining bit that's not yet addressed is being able to send props down to underlying components without redefining them all. I'll work on adding the `import_props` macro, which I think should address that.

Resolves #2 
Closes #68 