### PR TITLE
take advantage of :attrs for Live{Patch,Redirect}

### DIFF
--- a/lib/surface/components/live_patch.ex
+++ b/lib/surface/components/live_patch.ex
@@ -29,6 +29,11 @@ defmodule Surface.Components.LivePatch do
   property label, :string
 
   @doc """
+  Additional attributes to add onto the generated element
+  """
+  property opts, :keyword
+
+  @doc """
   The content of the generated `<a>` element. If no content is provided,
   the value of property `label` is used instead.
   """
@@ -44,6 +49,7 @@ defmodule Surface.Components.LivePatch do
       class={{ @class }}
       href={{ @to }}
       to={{ @to }}
+      :attrs={{ @opts }}
     >
       <slot>{{ @label }}</slot>
     </a>

--- a/lib/surface/components/live_patch.ex
+++ b/lib/surface/components/live_patch.ex
@@ -39,14 +39,12 @@ defmodule Surface.Components.LivePatch do
   """
   slot default
 
-  def render(%{replace: replace} = assigns) do
-    link_state = if replace, do: "replace", else: "push"
-
+  def render(assigns) do
     ~H"""
     <a
       class={{ @class }}
       data-phx-link="patch"
-      data-phx-link-state={{ link_state }}
+      data-phx-link-state={{ if @replace, do: "replace", else: "push" }}
       href={{ @to }}
       :attrs={{ @opts }}
     ><slot>{{ @label }}</slot></a>

--- a/lib/surface/components/live_patch.ex
+++ b/lib/surface/components/live_patch.ex
@@ -31,7 +31,7 @@ defmodule Surface.Components.LivePatch do
   @doc """
   Additional attributes to add onto the generated element
   """
-  property opts, :keyword
+  property opts, :keyword, default: []
 
   @doc """
   The content of the generated `<a>` element. If no content is provided,
@@ -44,15 +44,12 @@ defmodule Surface.Components.LivePatch do
 
     ~H"""
     <a
+      class={{ @class }}
       data-phx-link="patch"
       data-phx-link-state={{ link_state }}
-      class={{ @class }}
       href={{ @to }}
-      to={{ @to }}
       :attrs={{ @opts }}
-    >
-      <slot>{{ @label }}</slot>
-    </a>
+    ><slot>{{ @label }}</slot></a>
     """
   end
 end

--- a/lib/surface/components/live_redirect.ex
+++ b/lib/surface/components/live_redirect.ex
@@ -29,6 +29,11 @@ defmodule Surface.Components.LiveRedirect do
   property label, :string
 
   @doc """
+  Additional attributes to add onto the generated element
+  """
+  property opts, :keyword
+
+  @doc """
   The content of the generated `<a>` element. If no content is provided,
   the value of property `label` is used instead.
   """
@@ -44,6 +49,7 @@ defmodule Surface.Components.LiveRedirect do
       class={{ @class }}
       href={{ @to }}
       to={{ @to }}
+      :attrs={{ @opts }}
     >
       <slot>{{ @label }}</slot>
     </a>

--- a/lib/surface/components/live_redirect.ex
+++ b/lib/surface/components/live_redirect.ex
@@ -31,7 +31,7 @@ defmodule Surface.Components.LiveRedirect do
   @doc """
   Additional attributes to add onto the generated element
   """
-  property opts, :keyword
+  property opts, :keyword, default: []
 
   @doc """
   The content of the generated `<a>` element. If no content is provided,
@@ -44,15 +44,12 @@ defmodule Surface.Components.LiveRedirect do
 
     ~H"""
     <a
+      class={{ @class }}
       data-phx-link="redirect"
       data-phx-link-state={{ link_state }}
-      class={{ @class }}
       href={{ @to }}
-      to={{ @to }}
       :attrs={{ @opts }}
-    >
-      <slot>{{ @label }}</slot>
-    </a>
+    ><slot>{{ @label }}</slot></a>
     """
   end
 end

--- a/lib/surface/components/live_redirect.ex
+++ b/lib/surface/components/live_redirect.ex
@@ -39,14 +39,12 @@ defmodule Surface.Components.LiveRedirect do
   """
   slot default
 
-  def render(%{replace: replace} = assigns) do
-    link_state = if replace, do: "replace", else: "push"
-
+  def render(assigns) do
     ~H"""
     <a
       class={{ @class }}
       data-phx-link="redirect"
-      data-phx-link-state={{ link_state }}
+      data-phx-link-state={{ if @replace, do: "replace", else: "push" }}
       href={{ @to }}
       :attrs={{ @opts }}
     ><slot>{{ @label }}</slot></a>

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -156,7 +156,7 @@ defmodule Surface.TypeHandler do
         [~S( ), to_string(name)]
 
       {:ok, val} ->
-        [" ", to_string(name), "=", ~S("), val, ~S(")]
+        [" ", to_string(name), "=", ~S("), to_string(val), ~S(")]
 
       {:error, message} ->
         IOHelper.runtime_error(message)

--- a/test/components/live_patch_test.exs
+++ b/test/components/live_patch_test.exs
@@ -1,0 +1,93 @@
+defmodule Surface.Components.LivePatchTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.Components.LivePatch, warn: false
+
+  import ComponentTestHelper
+
+  defmodule ComponentWithLink do
+    use Surface.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <LivePatch to="/users/1"/>
+      </div>
+      """
+    end
+
+    def handle_event(_, _, socket) do
+      {:noreply, socket}
+    end
+  end
+
+  describe "Without LiveView" do
+    test "creates a link with label" do
+      code = """
+      <LivePatch label="user" to="/users/1" />
+      """
+
+      assert render_live(code) =~ actual_content("user", to: "/users/1")
+    end
+
+    test "creates a link without label" do
+      code = """
+      <LivePatch to="/users/1" />
+      """
+
+      assert render_live(code) =~ actual_content(to: "/users/1")
+    end
+
+    test "creates a link with default slot" do
+      code = """
+      <LivePatch to="/users/1"><span>user</span></LivePatch>
+      """
+
+      assert render_live(code) =~ actual_content({:safe, "<span>user</span>"}, to: "/users/1")
+    end
+
+    test "setting the class" do
+      code = """
+      <LivePatch label="user" to="/users/1" class="link" />
+      """
+
+      assert render_live(code) =~
+               actual_content("user", to: "/users/1", class: "link")
+    end
+
+    test "passing other options" do
+      code = """
+      <LivePatch label="user" to="/users/1" class="link" opts={{ method: :delete, "data-confirm": "Really?", "csrf-token": "token" }} />
+      """
+
+      rendered = render_live(code)
+
+      actual =
+        actual_content("user",
+          to: "/users/1",
+          class: "link",
+          method: :delete,
+          data: [confirm: "Really?"],
+          csrf_token: "token"
+        )
+
+      assert attr_map(rendered) == attr_map(actual)
+    end
+  end
+
+  def attr_map(html) do
+    [{_, attrs, _}] = Floki.parse_fragment!(html)
+
+    Map.new(attrs)
+  end
+
+  defp actual_content(text, opts) do
+    text
+    |> Phoenix.LiveView.Helpers.live_patch(opts)
+    |> Phoenix.HTML.safe_to_string()
+  end
+
+  defp actual_content(opts) do
+    actual_content("", opts)
+  end
+end

--- a/test/components/live_redirect_test.exs
+++ b/test/components/live_redirect_test.exs
@@ -1,0 +1,93 @@
+defmodule Surface.Components.LiveRedirectTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.Components.LiveRedirect, warn: false
+
+  import ComponentTestHelper
+
+  defmodule ComponentWithLink do
+    use Surface.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <LiveRedirect to="/users/1"/>
+      </div>
+      """
+    end
+
+    def handle_event(_, _, socket) do
+      {:noreply, socket}
+    end
+  end
+
+  describe "Without LiveView" do
+    test "creates a link with label" do
+      code = """
+      <LiveRedirect label="user" to="/users/1" />
+      """
+
+      assert render_live(code) =~ actual_content("user", to: "/users/1")
+    end
+
+    test "creates a link without label" do
+      code = """
+      <LiveRedirect to="/users/1" />
+      """
+
+      assert render_live(code) =~ actual_content(to: "/users/1")
+    end
+
+    test "creates a link with default slot" do
+      code = """
+      <LiveRedirect to="/users/1"><span>user</span></LiveRedirect>
+      """
+
+      assert render_live(code) =~ actual_content({:safe, "<span>user</span>"}, to: "/users/1")
+    end
+
+    test "setting the class" do
+      code = """
+      <LiveRedirect label="user" to="/users/1" class="link" />
+      """
+
+      assert render_live(code) =~
+               actual_content("user", to: "/users/1", class: "link")
+    end
+
+    test "passing other options" do
+      code = """
+      <LiveRedirect label="user" to="/users/1" class="link" opts={{ method: :delete, "data-confirm": "Really?", "csrf-token": "token" }} />
+      """
+
+      rendered = render_live(code)
+
+      actual =
+        actual_content("user",
+          to: "/users/1",
+          class: "link",
+          method: :delete,
+          data: [confirm: "Really?"],
+          csrf_token: "token"
+        )
+
+      assert attr_map(rendered) == attr_map(actual)
+    end
+  end
+
+  def attr_map(html) do
+    [{_, attrs, _}] = Floki.parse_fragment!(html)
+
+    Map.new(attrs)
+  end
+
+  defp actual_content(text, opts) do
+    text
+    |> Phoenix.LiveView.Helpers.live_redirect(opts)
+    |> Phoenix.HTML.safe_to_string()
+  end
+
+  defp actual_content(opts) do
+    actual_content("", opts)
+  end
+end


### PR DESCRIPTION
This allows folks to add attributes like `aria-*` attributes to the generated anchor tag. I went for `opts` to be consistent with the `Link` component.

i don't think we have any other components currently where this is necessary