### PR TITLE
Fix typo when consuming context

### DIFF
--- a/lib/surface/content_handler.ex
+++ b/lib/surface/content_handler.ex
@@ -61,7 +61,7 @@ defmodule Surface.ContentHandler do
   defp data_content_fun(assigns, name, index) do
     fn
       {args, ctx_assigns} ->
-        assigns.inner_content({name, index, {args_to_map(args), ctx_assigns}})
+        assigns.inner_content.({name, index, {args_to_map(args), ctx_assigns}})
 
       args ->
         assigns.inner_content.({name, index, {args_to_map(args), assigns}})


### PR DESCRIPTION
Fixes missing `.` when consuming `ctx_assigns`. 

Great work on the library so far, really enjoying the developer ergonomics this offers. 