### PR TITLE
fix typing errors

### DIFF
--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -30,7 +30,7 @@ defmodule Surface.AST.Container do
 
   @type t :: %__MODULE__{
           children: list(Surface.AST.t()),
-          debug: List.t(atom()),
+          debug: list(atom()),
           meta: Surface.AST.Meta.t(),
           directives: list(Surface.AST.Directive.t())
         }
@@ -126,7 +126,7 @@ defmodule Surface.AST.For do
 
   @type t :: %__MODULE__{
           generator: any(),
-          debug: List.t(atom()),
+          debug: list(atom()),
           children: list(Surface.AST.t()),
           meta: Surface.AST.Meta.t()
         }
@@ -146,7 +146,7 @@ defmodule Surface.AST.If do
 
   @type t :: %__MODULE__{
           condition: any(),
-          debug: List.t(atom()),
+          debug: list(atom()),
           children: list(Surface.AST.t()),
           meta: Surface.AST.Meta.t()
         }
@@ -278,7 +278,7 @@ defmodule Surface.AST.Tag do
 
   @type t :: %__MODULE__{
           element: binary(),
-          debug: List.t(atom()),
+          debug: list(atom()),
           attributes: list(Surface.AST.Attribute.t() | Surface.AST.DynamicAttribute.t()),
           directives: list(Surface.AST.Directive.t()),
           children: list(Surface.AST.t()),
@@ -301,7 +301,7 @@ defmodule Surface.AST.VoidTag do
 
   @type t :: %__MODULE__{
           element: binary(),
-          debug: List.t(atom()),
+          debug: list(atom()),
           attributes: list(Surface.AST.Attribute.t() | Surface.AST.DynamicAttribute.t()),
           directives: list(Surface.AST.Directive.t()),
           meta: Surface.AST.Meta.t()
@@ -342,7 +342,7 @@ defmodule Surface.AST.Error do
 
   @type t :: %__MODULE__{
           message: binary(),
-          meta: Surface.HTML.Meta.t()
+          meta: Surface.AST.Meta.t()
         }
 end
 
@@ -363,7 +363,7 @@ defmodule Surface.AST.Component do
 
   @type t :: %__MODULE__{
           module: module(),
-          debug: List.t(atom()),
+          debug: list(atom()),
           type: module(),
           props: list(Surface.AST.Attribute.t()),
           dynamic_props: Surface.AST.DynamicAttribute.t(),
@@ -406,7 +406,7 @@ defmodule Surface.AST.SlotableComponent do
 
   @type t :: %__MODULE__{
           module: module(),
-          debug: List.t(atom()),
+          debug: list(atom()),
           type: module(),
           slot: atom(),
           let: Surface.AST.Directive.t(),

--- a/lib/surface/directive/debug.ex
+++ b/lib/surface/directive/debug.ex
@@ -57,7 +57,7 @@ defmodule Surface.Directive.Debug do
 
     for name <- expr do
       if not is_atom(name) do
-        invalid_debug_value(value, meta)
+        invalid_debug_value!(value, meta)
       end
     end
 
@@ -68,7 +68,8 @@ defmodule Surface.Directive.Debug do
     }
   end
 
-  defp invalid_debug_value(value, meta) do
+  @spec invalid_debug_value!(any(), Surface.AST.Meta.t()) :: no_return()
+  defp invalid_debug_value!(value, meta) do
     message = """
     invalid value for directive :debug. Expected a list of atoms, \
     got: #{String.trim(value)}.\

--- a/lib/surface/macro_component.ex
+++ b/lib/surface/macro_component.ex
@@ -9,7 +9,7 @@ defmodule Surface.MacroComponent do
   set of Surface.AST nodes.
   """
   @callback expand(
-              attributes :: [Surface.Attribute.t()],
+              attributes :: [Surface.AST.Attribute.t()],
               children :: iodata(),
               meta :: Surface.AST.Meta.t()
             ) :: Surface.AST.t() | [Surface.AST.t()]

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -11,7 +11,8 @@ defmodule Surface.TypeHandler do
               name :: atom(),
               value :: any(),
               meta :: Surface.AST.Meta.t()
-            ) :: Surface.AST.Text | Surface.AST.AttributeExpr
+            ) ::
+              {:ok, Surface.AST.Text.t() | Surface.AST.AttributeExpr.t()} | {:error, String.t()} | :error
 
   @callback expr_to_quoted(
               type :: atom(),

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -12,7 +12,9 @@ defmodule Surface.TypeHandler do
               value :: any(),
               meta :: Surface.AST.Meta.t()
             ) ::
-              {:ok, Surface.AST.Text.t() | Surface.AST.AttributeExpr.t()} | {:error, String.t()} | :error
+              {:ok, Surface.AST.Text.t() | Surface.AST.AttributeExpr.t()}
+              | {:error, String.t()}
+              | :error
 
   @callback expr_to_quoted(
               type :: atom(),


### PR DESCRIPTION
Some quick fixes to address a few errors we had in our typings and to silence dialyzer in debug.ex. There's still an issue in type_handler.ex on line 112, but I don't quite get why that's showing an error and didn't want to spend a lot of time debugging it.