### PR TITLE
Slot change tracking fixes

### DIFF
--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -140,7 +140,7 @@ defmodule Surface.Compiler.EExEngine do
     slot_content_expr =
       if name == :default do
         quote generated: true do
-          unquote(at_ref(:inner_content)).(unquote(slot_prop_expr))
+          @inner_content.(unquote(slot_prop_expr))
         end
       else
         slot_name_expr = at_ref(name)
@@ -162,7 +162,7 @@ defmodule Surface.Compiler.EExEngine do
     name_to_check = if name == :default, do: :__default__, else: name
 
     quote generated: true do
-      if Enum.member?(unquote(at_ref(:__surface__)).provided_templates, unquote(name_to_check)) do
+      if Enum.member?(@__surface__.provided_templates, unquote(name_to_check)) do
         unquote(slot_content_expr)
       else
         unquote(default_value)
@@ -185,7 +185,7 @@ defmodule Surface.Compiler.EExEngine do
 
     quote generated: true do
       live_render(
-        unquote(at_ref(:socket)),
+        @socket,
         unquote(module),
         unquote(props_expr)
       )
@@ -218,13 +218,13 @@ defmodule Surface.Compiler.EExEngine do
         end
       else
         quote generated: true do
-          unquote(at_ref(:__surface__))[:context] || []
+          @__surface__[:context] || []
         end
       end
 
     quote generated: true do
       live_component(
-        unquote(at_ref(:socket)),
+        @socket,
         unquote(module),
         Surface.build_assigns(
           unquote(assigns_expr),

--- a/lib/surface/content_handler.ex
+++ b/lib/surface/content_handler.ex
@@ -17,10 +17,10 @@ defmodule Surface.ContentHandler do
   end
 
   def init_contents(assigns, module) do
-    {%{__default__: default_slot}, _other_slots} =
+    {%{__default__: default_slot}, other_slots} =
       case assigns[:__surface__][:slots] do
         nil ->
-          {%{__default__: %{size: 0}}, []}
+          {%{__default__: %{size: 0, prop_assigns: []}}, []}
 
         slots ->
           Map.split(slots, [:__default__])
@@ -38,7 +38,12 @@ defmodule Surface.ContentHandler do
               Map.put(
                 assign,
                 :inner_content,
-                data_content_fun(assigns, name, index)
+                data_content_fun(
+                  assigns,
+                  name,
+                  index,
+                  Enum.at(other_slots[name][:prop_assigns] || [], index, [])
+                )
               )
             end)
           end
@@ -46,7 +51,7 @@ defmodule Surface.ContentHandler do
         {name, value}
       end
 
-    content = default_content_fun(assigns, default_slot.size)
+    content = default_content_fun(assigns, default_slot.size, default_slot.prop_assigns)
 
     assigns =
       if default_slot.size > 0 do
@@ -58,34 +63,59 @@ defmodule Surface.ContentHandler do
     Map.merge(assigns, props)
   end
 
-  defp data_content_fun(assigns, name, index) do
-    fn
-      {args, ctx_assigns} ->
-        assigns.inner_content.({name, index, {args_to_map(args), ctx_assigns}})
+  defp data_content_fun(assigns, name, index, prop_assign_mappings) do
+    fn args ->
+      prop_assigns =
+        Enum.map(prop_assign_mappings, fn {prop_name, assign_name} ->
+          {assign_name, args[prop_name]}
+        end)
 
-      args ->
-        assigns.inner_content.({name, index, {args_to_map(args), assigns}})
+      # TODO [Context]: Update this to be only the appropriate assigns for context
+      surface_assign =
+        if Keyword.has_key?(args, :__surface__) do
+          [__surface__: args[:__surface__]]
+        else
+          []
+        end
+
+      assigns.inner_content.(
+        Keyword.merge(prop_assigns ++ surface_assign, __slot__: {name, index})
+      )
     end
   end
 
-  defp default_content_fun(assigns, size) do
-    fn
-      {args, ctx_assigns} -> join_contents(assigns, size, args_to_map(args), ctx_assigns)
-      args -> join_contents(assigns, size, args_to_map(args), assigns)
+  defp default_content_fun(assigns, size, all_prop_assign_mappings) do
+    fn args ->
+      # TODO [Context]: Update this to be only the appropriate assigns for context
+      surface_assign =
+        if Keyword.has_key?(args, :__surface__) do
+          [__surface__: args[:__surface__]]
+        else
+          []
+        end
+
+      prop_assigns =
+        Enum.map(all_prop_assign_mappings, fn mappings_for_index ->
+          Enum.map(mappings_for_index, fn {prop_name, assign_name} ->
+            {assign_name, args[prop_name]}
+          end)
+        end)
+
+      join_contents(assigns, size, surface_assign, prop_assigns)
     end
   end
 
-  defp join_contents(assigns, size, args, assigns_to_pass) do
+  defp join_contents(assigns, size, surface_assign, assign_mappings) do
     ~L"""
     <%= if assigns[:inner_content] != nil do %>
-    <%= for index <- 0..size-1 do %><%= assigns.inner_content.({:__default__, index, {args, assigns_to_pass}}) %><% end %>
+    <%= for index <- 0..size-1 do %><%= assigns.inner_content.(Keyword.merge(Enum.at(assign_mappings, index) ++ surface_assign, [__slot__: {:__default__, index}])) %><% end %>
     <% end %>
     """
   end
 
-  defp args_to_map(args) do
+  defp args_to_keyword(args) do
     if Keyword.keyword?(args) do
-      Map.new(args)
+      args
     else
       stacktrace =
         self()

--- a/lib/surface/content_handler.ex
+++ b/lib/surface/content_handler.ex
@@ -75,7 +75,7 @@ defmodule Surface.ContentHandler do
         if Keyword.has_key?(args, :__surface__) do
           [__surface__: args[:__surface__]]
         else
-          []
+          [__surface__: assigns.__surface__]
         end
 
       assigns.inner_content.(
@@ -91,7 +91,7 @@ defmodule Surface.ContentHandler do
         if Keyword.has_key?(args, :__surface__) do
           [__surface__: args[:__surface__]]
         else
-          []
+          [__surface__: assigns.__surface__]
         end
 
       prop_assigns =

--- a/lib/surface/content_handler.ex
+++ b/lib/surface/content_handler.ex
@@ -71,15 +71,10 @@ defmodule Surface.ContentHandler do
         end)
 
       # TODO [Context]: Update this to be only the appropriate assigns for context
-      surface_assign =
-        if Keyword.has_key?(args, :__surface__) do
-          [__surface__: args[:__surface__]]
-        else
-          [__surface__: assigns.__surface__]
-        end
+      surface_assign = args[:__surface__] || assigns.__surface__
 
       assigns.inner_content.(
-        Keyword.merge(prop_assigns ++ surface_assign, __slot__: {name, index})
+        Keyword.merge(prop_assigns, [__slot__: {name, index}, __surface__: surface_assign])
       )
     end
   end
@@ -87,12 +82,7 @@ defmodule Surface.ContentHandler do
   defp default_content_fun(assigns, size, all_prop_assign_mappings) do
     fn args ->
       # TODO [Context]: Update this to be only the appropriate assigns for context
-      surface_assign =
-        if Keyword.has_key?(args, :__surface__) do
-          [__surface__: args[:__surface__]]
-        else
-          [__surface__: assigns.__surface__]
-        end
+      surface_assign = args[:__surface__] || assigns.__surface__
 
       prop_assigns =
         Enum.map(all_prop_assign_mappings, fn mappings_for_index ->
@@ -108,7 +98,7 @@ defmodule Surface.ContentHandler do
   defp join_contents(assigns, size, surface_assign, assign_mappings) do
     ~L"""
     <%= if assigns[:inner_content] != nil do %>
-    <%= for index <- 0..size-1 do %><%= assigns.inner_content.(Keyword.merge(Enum.at(assign_mappings, index) ++ surface_assign, [__slot__: {:__default__, index}])) %><% end %>
+    <%= for index <- 0..size-1 do %><%= assigns.inner_content.(Keyword.merge(Enum.at(assign_mappings, index), [__slot__: {:__default__, index}, __surface__: surface_assign])) %><% end %>
     <% end %>
     """
   end

--- a/lib/surface/content_handler.ex
+++ b/lib/surface/content_handler.ex
@@ -112,19 +112,4 @@ defmodule Surface.ContentHandler do
     <% end %>
     """
   end
-
-  defp args_to_keyword(args) do
-    if Keyword.keyword?(args) do
-      args
-    else
-      stacktrace =
-        self()
-        |> Process.info(:current_stacktrace)
-        |> elem(1)
-        |> Enum.drop(3)
-
-      message = "invalid slot props. Expected a keyword list, got: #{inspect(args)}"
-      reraise(message, stacktrace)
-    end
-  end
 end

--- a/lib/surface/content_handler.ex
+++ b/lib/surface/content_handler.ex
@@ -74,7 +74,7 @@ defmodule Surface.ContentHandler do
       surface_assign = args[:__surface__] || assigns.__surface__
 
       assigns.inner_content.(
-        Keyword.merge(prop_assigns, [__slot__: {name, index}, __surface__: surface_assign])
+        Keyword.merge(prop_assigns, __slot__: {name, index}, __surface__: surface_assign)
       )
     end
   end

--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -85,7 +85,7 @@ defmodule Surface.ComponentTest do
     def render(assigns) do
       ~H"""
       <OuterWithSlotProps :let={{ info: my_info }}>
-        {{ my_info }}
+        {{ @my_info }}
       </OuterWithSlotProps>
       """
     end
@@ -174,7 +174,7 @@ defmodule Surface.ComponentTest do
     test "render content with slot props" do
       code = """
       <OuterWithSlotProps :let={{ info: my_info }}>
-        {{ my_info }}
+        {{ @my_info }}
       </OuterWithSlotProps>
       """
 

--- a/test/live_component_test.exs
+++ b/test/live_component_test.exs
@@ -100,7 +100,7 @@ defmodule LiveComponentTest do
   test "render content with slot props" do
     code = """
     <InfoProvider :let={{ info: my_info }}>
-      <span>{{ my_info }}</span>
+      <span>{{ @my_info }}</span>
     </InfoProvider>
     """
 

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -220,7 +220,7 @@ defmodule Surface.SlotTest do
     code = """
     <OuterWithSlotNotationAndProps>
       <template slot="body" :let={{ info: my_info }}>
-        Info: {{ my_info }}
+        Info: {{ @my_info }}
       </template>
     </OuterWithSlotNotationAndProps>
     """
@@ -237,7 +237,7 @@ defmodule Surface.SlotTest do
   test "assign default slot with props using <slot/> notation" do
     code = """
     <OuterWithSlotNotationDefaultAndProps :let={{ info: my_info }}>
-      Info: {{ my_info }}
+      Info: {{ @my_info }}
     </OuterWithSlotNotationDefaultAndProps>
     """
 
@@ -335,7 +335,7 @@ defmodule Surface.SlotTest do
     code = """
     <Grid items={{ user <- @items }}>
       <ColumnWithDefaultTitle>
-        <b>Id: {{ user.id }}</b>
+        <b>Id: {{ @user.id }}</b>
       </ColumnWithDefaultTitle>
     </Grid>
     """
@@ -361,10 +361,10 @@ defmodule Surface.SlotTest do
     code = """
     <Grid items={{ user <- @items }}>
       <Column title="ID">
-        <b>Id: {{ user.id }}</b>
+        <b>Id: {{ @user.id }}</b>
       </Column>
       <Column title="NAME">
-        Name: {{ user.name }}
+        Name: {{ @user.name }}
       </Column>
     </Grid>
     """
@@ -392,11 +392,11 @@ defmodule Surface.SlotTest do
     code = """
     <Grid items={{ user <- @items }}>
       <Column title="ID" :let={{ item: my_user }}>
-        <b>Id: {{ my_user.id }}</b>
+        <b>Id: {{ @my_user.id }}</b>
       </Column>
       <Column title="NAME" :let={{ info: my_info }}>
-        Name: {{ user.name }}
-        Info: {{ my_info }}
+        Name: {{ @user.name }}
+        Info: {{ @my_info }}
       </Column>
     </Grid>
     """
@@ -422,7 +422,7 @@ defmodule Surface.SlotTest do
     code = """
     <Grid items={{ user <- @items }}>
       <Column title="ID" :let={{ item: my_user, non_existing: value}}>
-        <b>Id: {{ my_user.id }}</b>
+        <b>Id: {{ @my_user.id }}</b>
       </Column>
     </Grid>
     """
@@ -447,7 +447,7 @@ defmodule Surface.SlotTest do
     code = """
     <OuterWithSlotNotationAndProps>
       <template slot="body" :let={{ :an_atom }}>
-        Info: {{ my_info }}
+        Info: {{ @my_info }}
       </template>
     </OuterWithSlotNotationAndProps>
     """
@@ -465,7 +465,7 @@ defmodule Surface.SlotTest do
   test "render default inner_content with slot props" do
     code = """
     <OuterWithDefaultSlotAndProps :let={{ info: my_info }}>
-      Info: {{ my_info }}
+      Info: {{ @my_info }}
     </OuterWithDefaultSlotAndProps>
     """
 
@@ -481,7 +481,7 @@ defmodule Surface.SlotTest do
   test "raise compile error when using :let and there's no default slot defined" do
     code = """
     <OuterWithoutDefaultSlot :let={{ info: my_info }}>
-      Info: {{ my_info }}
+      Info: {{ @my_info }}
     </OuterWithoutDefaultSlot>
     """
 
@@ -502,7 +502,7 @@ defmodule Surface.SlotTest do
   test "raise compile error when using :let with undefined props for default slot" do
     code = """
     <OuterWithDefaultSlotAndProps :let={{ info: my_info, non_existing: value }}>
-      Info: {{ my_info }}
+      Info: {{ @my_info }}
     </OuterWithDefaultSlotAndProps>
     """
 
@@ -524,7 +524,7 @@ defmodule Surface.SlotTest do
   test "raise compile error when using :let with invalid list of bindings" do
     code = """
     <OuterWithDefaultSlotAndProps :let={{ info: 1 }}>
-      Info: {{ my_info }}
+      Info: {{ @my_info }}
     </OuterWithDefaultSlotAndProps>
     """
 
@@ -542,7 +542,7 @@ defmodule Surface.SlotTest do
     code = """
     <OuterWithSlotNotationAndProps>
       <template slot="body" :let={{ non_existing: my_info }}>
-        Info: {{ my_info }}
+        Info: {{ @my_info }}
       </template>
     </OuterWithSlotNotationAndProps>
     """


### PR DESCRIPTION
This doesn't make drastic changes to the API - `:let` and `:prop` still work the exact same. The only difference is that bound props within a template have to be accessed as assigns instead of as variables. I did not change the `:let` binding syntax, but that's something we can do if we decide it's worth it.

As a plus, it removes the kind of wonky `ctx_assigns` variable, and instead just relies on rebinding that assign using `inner_content`

There are still a few tests failing, but I think I have an idea why that is. 