### PR TITLE
add phx-page-loading to boolean attributes list

### DIFF
--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -66,7 +66,8 @@ defmodule Surface.TypeHandler do
     :required,
     :reversed,
     :selected,
-    :typemustmatch
+    :typemustmatch,
+    :"phx-page-loading"
   ]
 
   @phx_event_attributes Surface.Directive.Events.phx_events() |> Enum.map(&String.to_atom/1)


### PR DESCRIPTION
This appears to be used as a boolean attribute, https://hexdocs.pm/phoenix_live_view/js-interop.html#loading-state-and-errors references this attribute