### PR TITLE
Add an unreleased section to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## UNRELEASED
+  
+  * Update LiveView to v0.14
+  * Add `Surface.init/1` to initialize internal assigns when not using `Surface.LiveView`
+  * Update slot props to create inner assigns instead of variables
+  * Add support for co-located template files using `.sface` suffix
+  * Add `:props` directive to pass dynamic props to a component
+  * Add `:attrs` directive to pass dynamic attributes to a tag
+  * Update html tag generation to remove the tag if it's value computes to nil
+
 ## v0.1.0-alpha.2 (2020-06-09)
 
   * New Markdown component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## UNRELEASED
+## v0.1.0-dev
   
   * Update LiveView to v0.14
   * Add `Surface.init/1` to initialize internal assigns when not using `Surface.LiveView`

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -4,6 +4,7 @@ defmodule Surface.AST do
           | Surface.AST.Interpolation.t()
           | Surface.AST.Expr.t()
           | Surface.AST.Tag.t()
+          | Surface.AST.VoidTag.t()
           | Surface.AST.Template.t()
           | Surface.AST.Slot.t()
           | Surface.AST.If.t()


### PR DESCRIPTION
I'm not sure if I hit everything, basically generated this from looking at the log between `v0.1.0-alpha.2` and `master`.

We can also change `UNRELEASED` to something else - it looks like `version-dev` (e.g. `0.1.0-dev`) is a common convention, just let me know your preference