### PR TITLE
Simplify prop_to_opts/3

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -249,6 +249,13 @@ defmodule Surface do
   end
 
   @doc false
+  defmacro prop_to_opts(prop_value, prop_name) do
+    quote do
+      prop_to_opts(unquote(prop_value), unquote(prop_name), __ENV__)
+    end
+  end
+
+  @doc false
   def prop_to_opts(nil, _prop_name, _caller) do
     []
   end

--- a/lib/surface/components/form/submit.ex
+++ b/lib/surface/components/form/submit.ex
@@ -40,7 +40,7 @@ defmodule Surface.Components.Form.Submit do
     children = ~H"<slot>{{ @label }}</slot>"
 
     ~H"""
-    {{ submit prop_to_opts(@class, :class, __ENV__) ++ @opts, do: children }}
+    {{ submit prop_to_opts(@class, :class) ++ @opts, do: children }}
     """
   end
 end

--- a/lib/surface/components/form/utils.ex
+++ b/lib/surface/components/form/utils.ex
@@ -1,6 +1,6 @@
 defmodule Surface.Components.Form.Utils do
   @moduledoc false
-  import Surface, only: [event_to_opts: 2]
+  import Surface, only: [event_to_opts: 2, prop_to_opts: 2]
 
   def get_form(%{form: form}) when is_binary(form), do: String.to_atom(form)
   def get_form(%{form: nil, form_context: form_context}), do: form_context
@@ -10,23 +10,11 @@ defmodule Surface.Components.Form.Utils do
 
   defmacro get_non_nil_props(assigns, props) do
     quote do
-      unquote(__MODULE__).get_non_nil_props(unquote(assigns), unquote(props), __ENV__)
+      Enum.reduce(unquote(props), [], fn prop, acc ->
+        {key, value} = unquote(__MODULE__).prop_value(unquote(assigns), prop)
+        prop_to_opts(value, key) ++ acc
+      end)
     end
-  end
-
-  def get_non_nil_props(assigns, props, caller) do
-    module = caller.module
-    meta = %{caller: caller, line: caller.line, node_alias: module}
-
-    Enum.reduce(props, [], fn prop, acc ->
-      {key, value} = prop_value(assigns, prop)
-      {type, _opts} = Surface.TypeHandler.attribute_type_and_opts(module, key, meta)
-
-      internal_value =
-        Surface.TypeHandler.expr_to_value!(type, key, [value], [], module, inspect(value))
-
-      Surface.TypeHandler.attr_to_opts!(type, key, internal_value) ++ acc
-    end)
   end
 
   def get_events_to_opts(assigns) do
@@ -40,11 +28,15 @@ defmodule Surface.Components.Form.Utils do
     |> List.flatten()
   end
 
-  defp prop_value(assigns, {prop, default}) do
+  def prop_value(assigns, {prop, default}) when is_list(default) do
     {prop, assigns[prop] || default}
   end
 
-  defp prop_value(assigns, prop) do
+  def prop_value(assigns, {prop, default}) do
+    {prop, assigns[prop] || [default]}
+  end
+
+  def prop_value(assigns, prop) do
     {prop, assigns[prop]}
   end
 end

--- a/lib/surface/components/link.ex
+++ b/lib/surface/components/link.ex
@@ -57,7 +57,7 @@ defmodule Surface.Components.Link do
     children = ~H"<slot>{{ @label }}</slot>"
 
     ~H"""
-    {{ link [to: @to] ++ prop_to_opts(@class, :class, __ENV__) ++ @opts ++ event_to_opts(@click, :phx_click), do: children }}
+    {{ link [to: @to] ++ prop_to_opts(@class, :class) ++ @opts ++ event_to_opts(@click, :phx_click), do: children }}
     """
   end
 end


### PR DESCRIPTION
Follow-up to PR https://github.com/msaraiva/surface/pull/132

I started using the changes we made in PR https://github.com/msaraiva/surface/pull/132 and found it quite cumbersome and ugly to always have to pass `__ENV__` manually when using `prop_to_opts/3`. So I looked for a solution where we can hide that away, which also led to an opportunity to simplify `get_non_nil_props/2`.

Please let me know what you think.

Cheers