### PR TITLE
Add support for a transform callback

### DIFF
--- a/lib/surface/base_component.ex
+++ b/lib/surface/base_component.ex
@@ -8,6 +8,17 @@ defmodule Surface.BaseComponent do
   """
   @callback component_type() :: module()
 
+  @doc """
+  This function will be invoked with parsed AST node as the only argument. The result
+  will replace the original node in the AST.
+
+  This callback is invoked before directives are handled for this node, but after all
+  children of this node have been fully processed.
+  """
+  @callback transform(node :: Surface.AST.t()) :: Surface.AST.t()
+
+  @optional_callbacks transform: 1
+
   defmacro __using__(opts \\ []) do
     type = Keyword.get(opts, :type)
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -352,7 +352,7 @@ defmodule Surface.Compiler do
           }
         end
 
-      {:ok, result}
+      {:ok, maybe_call_transform(result)}
     else
       {:error, message} ->
         {:error, {"cannot render <#{name}> (#{message})", meta.line}, meta}
@@ -395,6 +395,14 @@ defmodule Surface.Compiler do
 
       _ ->
         {:error, {"cannot render <#{name}>", meta.line}, meta}
+    end
+  end
+
+  defp maybe_call_transform(%{module: module} = node) do
+    if function_exported?(module, :transform, 1) do
+      module.transform(node)
+    else
+      node
     end
   end
 

--- a/test/transform_test.exs
+++ b/test/transform_test.exs
@@ -20,6 +20,7 @@ defmodule Surface.TransformTest do
       """
     end
 
+    @impl Surface.BaseComponent
     def transform(node) do
       send(self(), {DivToSpan, "transforming node"})
       %{node | module: Span}
@@ -35,6 +36,7 @@ defmodule Surface.TransformTest do
       """
     end
 
+    @impl Surface.BaseComponent
     def transform(node) do
       send(self(), {LiveDivToSpan, "transforming node"})
       %{node | module: Span, type: Surface.Component}
@@ -44,12 +46,14 @@ defmodule Surface.TransformTest do
   defmodule LiveDivViewToSpan do
     use Surface.LiveView
 
+    @impl true
     def render(assigns) do
       ~H"""
       <div><slot /></div>
       """
     end
 
+    @impl Surface.BaseComponent
     def transform(node) do
       send(self(), {LiveDivViewToSpan, "transforming node"})
       %{node | module: Span, type: Surface.Component}
@@ -59,6 +63,7 @@ defmodule Surface.TransformTest do
   defmodule MacroDivToSpan do
     use Surface.MacroComponent
 
+    @impl true
     def expand(_, _, _) do
       Surface.Compiler.compile(
         """
@@ -69,6 +74,7 @@ defmodule Surface.TransformTest do
       )
     end
 
+    @impl Surface.BaseComponent
     def transform(node) do
       send(self(), {MacroDivToSpan, "transforming node"})
       node
@@ -86,6 +92,7 @@ defmodule Surface.TransformTest do
       """
     end
 
+    @impl Surface.BaseComponent
     def transform(node) do
       send(self(), {ListProp, "transforming node"})
       node

--- a/test/transform_test.exs
+++ b/test/transform_test.exs
@@ -1,0 +1,180 @@
+defmodule Surface.TransformTest do
+  use ExUnit.Case
+
+  defmodule Span do
+    use Surface.Component
+
+    def render(assigns) do
+      ~H"""
+      <span><slot /></span>
+      """
+    end
+  end
+
+  defmodule DivToSpan do
+    use Surface.Component
+
+    def render(assigns) do
+      ~H"""
+      <div><slot /></div>
+      """
+    end
+
+    def transform(node) do
+      send(self(), {DivToSpan, "transforming node"})
+      %{node | module: Span}
+    end
+  end
+
+  defmodule LiveDivToSpan do
+    use Surface.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div><slot /></div>
+      """
+    end
+
+    def transform(node) do
+      send(self(), {LiveDivToSpan, "transforming node"})
+      %{node | module: Span, type: Surface.Component}
+    end
+  end
+
+  defmodule LiveDivViewToSpan do
+    use Surface.LiveView
+
+    def render(assigns) do
+      ~H"""
+      <div><slot /></div>
+      """
+    end
+
+    def transform(node) do
+      send(self(), {LiveDivViewToSpan, "transforming node"})
+      %{node | module: Span, type: Surface.Component}
+    end
+  end
+
+  defmodule MacroDivToSpan do
+    use Surface.MacroComponent
+
+    def expand(_, _, _) do
+      Surface.Compiler.compile(
+        """
+        <span>This is a test component. Don't do this at home.</span>
+        """,
+        1,
+        __ENV__
+      )
+    end
+
+    def transform(node) do
+      send(self(), {MacroDivToSpan, "transforming node"})
+      node
+    end
+  end
+
+  defmodule ListProp do
+    use Surface.Component
+
+    property prop, :list
+
+    def render(assigns) do
+      ~H"""
+      <span></span>
+      """
+    end
+
+    def transform(node) do
+      send(self(), {ListProp, "transforming node"})
+      node
+    end
+  end
+
+  test "transform is run on compile when defined for Surface.Component" do
+    code = """
+    <DivToSpan>Some content</DivToSpan>
+    """
+
+    [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
+
+    assert_receive {DivToSpan, "transforming node"}
+
+    assert %Surface.AST.Component{
+             module: Span
+           } = node
+  end
+
+  test "transform is run on compile when defined for Surface.LiveComponent" do
+    code = """
+    <LiveDivToSpan>Some content</LiveDivToSpan>
+    """
+
+    [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
+
+    assert_receive {LiveDivToSpan, "transforming node"}
+
+    assert %Surface.AST.Component{
+             module: Span
+           } = node
+  end
+
+  test "transform is run on compile when defined for Surface.LiveView" do
+    code = """
+    <LiveDivViewToSpan>Some content</LiveDivViewToSpan>
+    """
+
+    [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
+
+    assert_receive {LiveDivViewToSpan, "transforming node"}
+
+    assert %Surface.AST.Component{
+             module: Span
+           } = node
+  end
+
+  test "transform is NOT run on compile when defined for Surface.MacroComponent" do
+    code = """
+    <#MacroDivToSpan>Some content</#MacroDivToSpan>
+    """
+
+    [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
+
+    refute_receive {MacroDivToSpan, "transforming node"}
+
+    assert %Surface.AST.Container{} = node
+  end
+
+  test "transform is not run on parse errors" do
+    code = """
+    <DivToSpan>Invalid syntax (missing end tag)
+    """
+
+    assert_raise(
+      Surface.Compiler.ParseError,
+      "nofile:2: expected closing tag for \"DivToSpan\"",
+      fn ->
+        Surface.Compiler.compile(code, 1, __ENV__)
+      end
+    )
+
+    refute_receive {DivToSpan, "transforming node"}
+  end
+
+  test "transform is not run on compile errors" do
+    code = """
+    <ListProp prop="string" />
+    """
+
+    assert_raise(
+      CompileError,
+      "nofile:1: invalid value for property \"prop\". Expected a :list, got: \"string\".",
+      fn ->
+        Surface.Compiler.compile(code, 1, __ENV__)
+      end
+    )
+
+    refute_receive {ListProp, "transforming node"}
+  end
+end


### PR DESCRIPTION
As discussed in #130. I added it to the base even though it's not currently used for macro components - though it's feasible to do that I couldn't think of a use case which isn't already covered by the `expand` function