### PR TITLE
Inputs component

### DIFF
--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -240,14 +240,15 @@ defmodule Surface.AST.Slot do
       * `:props` - either an atom or a quoted expression representing bindings for this slot
       * `:meta` - compilation meta data
   """
-  defstruct [:name, :index, :props, :default, :meta]
+  defstruct [:name, :directives, :index, :props, :default, :meta]
 
   @type t :: %__MODULE__{
           name: binary(),
           index: any(),
+          directives: list(Surface.AST.Directive.t()),
           meta: Surface.AST.Meta.t(),
           # quoted ?
-          props: Surface.AST.Directive.t(),
+          props: list(Keyword.t(any())),
           default: list(Surface.AST.t())
         }
 end
@@ -324,13 +325,14 @@ defmodule Surface.AST.Template do
       * `:meta` - compilation meta data
       * `:debug` - keyword list indicating when debug information should be printed during compilation
   """
-  defstruct [:name, :children, :let, :meta]
+  defstruct [:name, :children, :directives, :let, :meta]
 
   @type t :: %__MODULE__{
           name: atom(),
           children: list(Surface.AST.t()),
+          directives: list(Surface.AST.Directive.t()),
           # quoted?
-          let: Surface.AST.Directive.t(),
+          let: list(Keyword.t(atom())),
           meta: Surface.AST.Meta.t()
         }
 end
@@ -414,7 +416,7 @@ defmodule Surface.AST.SlotableComponent do
           debug: list(atom()),
           type: module(),
           slot: atom(),
-          let: Surface.AST.Directive.t(),
+          let: list(Keyword.t(atom())),
           props: list(Surface.AST.Attribute.t()),
           dynamic_props: Surface.AST.DynamicAttribute.t(),
           directives: list(Surface.AST.Directive.t()),

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -438,8 +438,8 @@ defmodule Surface.Compiler do
     end)
   end
 
-  defp template_props([], meta),
-    do: %AST.Directive{
+  defp template_props([], meta) do
+    %AST.Directive{
       module: Surface.Directive.Let,
       name: :let,
       value: %AST.AttributeExpr{
@@ -449,11 +449,26 @@ defmodule Surface.Compiler do
       },
       meta: meta
     }
+  end
 
-  defp template_props([%AST.Directive{module: Surface.Directive.Let} = props | _], _meta),
-    do: props
+  defp template_props(directives, meta) do
+    values =
+      for %AST.Directive{module: Surface.Directive.Let, value: %AST.AttributeExpr{value: value}} <-
+            directives do
+        value
+      end
 
-  defp template_props([_ | directives], meta), do: template_props(directives, meta)
+    %AST.Directive{
+      module: Surface.Directive.Let,
+      name: :let,
+      value: %AST.AttributeExpr{
+        value: values,
+        original: "",
+        meta: meta
+      },
+      meta: meta
+    }
+  end
 
   defp component_slotable?(mod), do: function_exported?(mod, :__slot_name__, 0)
 

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -123,7 +123,7 @@ defmodule Surface.Compiler.EExEngine do
          %AST.Slot{
            name: name,
            index: index_ast,
-           props: %AST.Directive{value: %AST.AttributeExpr{value: props_expr}},
+           props: props_expr,
            default: default
          },
          buffer,
@@ -390,7 +390,7 @@ defmodule Surface.Compiler.EExEngine do
          [
            %AST.Template{
              name: name,
-             let: %AST.Directive{value: %AST.AttributeExpr{value: let}},
+             let: let,
              children: children
            }
            | tail
@@ -411,7 +411,7 @@ defmodule Surface.Compiler.EExEngine do
            %AST.SlotableComponent{
              slot: name,
              module: module,
-             let: %AST.Directive{value: %AST.AttributeExpr{value: let}},
+             let: let,
              props: props,
              templates: %{default: default}
            }

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -339,10 +339,7 @@ defmodule Surface.Compiler.EExEngine do
 
     slot_meta =
       for {name, size, infos} <- slot_info do
-        prop_assign_mappings =
-          Enum.map(infos, fn {let, _, _} ->
-            Enum.map(let, fn {prop_name, binding_name} -> {prop_name, binding_name} end)
-          end)
+        prop_assign_mappings = Enum.map(infos, fn {let, _, _} -> let end)
 
         meta_value =
           quote generated: true do

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -341,7 +341,7 @@ defmodule Surface.Compiler.EExEngine do
       for {name, size, infos} <- slot_info do
         prop_assign_mappings =
           Enum.map(infos, fn {let, _, _} ->
-            Enum.map(let, fn {prop_name, {binding_name, _, _}} -> {prop_name, binding_name} end)
+            Enum.map(let, fn {prop_name, binding_name} -> {prop_name, binding_name} end)
           end)
 
         meta_value =
@@ -444,7 +444,7 @@ defmodule Surface.Compiler.EExEngine do
     end)
     |> Enum.map(fn %{generator: gen, name: name} ->
       case find_attribute_value(props, gen, nil) do
-        %AST.AttributeExpr{value: {binding, _}} ->
+        %AST.AttributeExpr{value: {{binding, _, _}, _}} ->
           {name, binding}
 
         _ ->
@@ -601,11 +601,13 @@ defmodule Surface.Compiler.EExEngine do
                         let: %AST.Directive{
                           module: Surface.Directive.Let,
                           name: :let,
-                          value: %AST.AttributeExpr{
-                            original: "",
-                            value: [],
-                            meta: meta
-                          },
+                          value: [
+                            %AST.AttributeExpr{
+                              original: "",
+                              value: [],
+                              meta: meta
+                            }
+                          ],
                           meta: meta
                         },
                         children: [require_expression],

--- a/lib/surface/components/form/inputs.ex
+++ b/lib/surface/components/form/inputs.ex
@@ -35,11 +35,11 @@ defmodule Surface.Components.Form.Inputs do
 
   def render(assigns) do
     ~H"""
-    <div :for={{ f <- inputs_for(get_form(assigns), @for, @opts) }}>
-      <Context set={{ :form, f, scope: Surface.Components.Form }}>
-        <slot :props={{ form: f }}/>
-      </Context>
-    </div>
+    <Context
+      :for={{ f <- inputs_for(get_form(assigns), @for, @opts) }}
+      set={{ :form, f, scope: Surface.Components.Form }}>
+      <slot :props={{ form: f }}/>
+    </Context>
     """
   end
 end

--- a/lib/surface/components/form/inputs.ex
+++ b/lib/surface/components/form/inputs.ex
@@ -1,0 +1,45 @@
+defmodule Surface.Components.Form.Inputs do
+  @moduledoc """
+  A wrapper for `Phoenix.HTML.Form.html.inputs_for/3`.
+
+  Additionally, adds the generated form instance that is returned by `inputs_for/3`
+  into the context, making it available to any child input.
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form
+  import Surface.Components.Form.Utils
+
+  @doc """
+  The parent form.
+
+  It should either be a `Phoenix.HTML.Form` emitted by `form_for` or an atom.
+  """
+  property form, :form
+
+  @doc """
+  The name of the field related to the child inputs.
+  """
+  property for, :atom
+
+  @doc """
+  Extra options for `inputs_for/3`.
+
+  See `Phoenix.HTML.Form.html.inputs_for/4` for the available options.
+  """
+  property opts, :keyword, default: []
+
+  @doc "The code containing the input controls"
+  slot default, props: [:form]
+
+  def render(assigns) do
+    ~H"""
+    <div :for={{ f <- inputs_for(get_form(assigns), @for, @opts) }}>
+      <Context set={{ :form, f, scope: Surface.Components.Form }}>
+        <slot :props={{ form: f }}/>
+      </Context>
+    </div>
+    """
+  end
+end

--- a/lib/surface/directive/let.ex
+++ b/lib/surface/directive/let.ex
@@ -12,6 +12,10 @@ defmodule Surface.Directive.Let do
 
   def extract(_, _), do: []
 
+  def process(%AST.Directive{value: %AST.AttributeExpr{value: value}}, %{let: let} = node) do
+    %{node | let: [value | let]}
+  end
+
   defp directive_value(value, meta) do
     %AST.AttributeExpr{
       value: Surface.TypeHandler.expr_to_quoted!(value, ":let", :bindings, meta),

--- a/lib/surface/directive/slot_props.ex
+++ b/lib/surface/directive/slot_props.ex
@@ -12,6 +12,10 @@ defmodule Surface.Directive.SlotProps do
 
   def extract(_, _), do: []
 
+  def process(%AST.Directive{value: %AST.AttributeExpr{value: value}}, %AST.Slot{} = slot) do
+    %{slot | props: value}
+  end
+
   defp directive_value(value, meta) do
     %AST.AttributeExpr{
       value: Surface.TypeHandler.expr_to_quoted!(value, ":props", :keyword, meta),

--- a/lib/surface/type_handler/bindings.ex
+++ b/lib/surface/type_handler/bindings.ex
@@ -4,13 +4,24 @@ defmodule Surface.TypeHandler.Bindings do
   use Surface.TypeHandler
 
   @impl true
-  def expr_to_quoted(_type, _name, clauses, opts, _meta, _original) do
-    match_binding? = &match?({_prop, {var, _, nil}} when is_atom(var), &1)
+  def literal_to_ast_node(_type, _name, _value, _meta) do
+    :error
+  end
 
-    if clauses == [] and Enum.all?(opts, match_binding?) do
-      {:ok, opts}
-    else
-      {:error, "Expected a keyword list of bindings"}
-    end
+  @impl true
+  def expr_to_quoted(_type, _name, [key], [as: as], _meta, _original)
+      when is_atom(key) and is_atom(as) do
+    {:ok, {key, as}}
+  end
+
+  @impl true
+  def expr_to_quoted(_type, _name, [key], [], _meta, _original) when is_atom(key) do
+    {:ok, {key, key}}
+  end
+
+  @impl true
+  def expr_to_quoted(_type, _name, _clauses, _opts, _meta, _original) do
+    {:error,
+     "Expected a mapping from a slot prop to an assign, e.g. {{ :item }} or {{ :item, as: :user }}"}
   end
 end

--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -84,7 +84,7 @@ defmodule Surface.ComponentTest do
 
     def render(assigns) do
       ~H"""
-      <OuterWithSlotProps :let={{ info: my_info }}>
+      <OuterWithSlotProps :let={{ :info, as: :my_info }}>
         {{ @my_info }}
       </OuterWithSlotProps>
       """
@@ -173,7 +173,7 @@ defmodule Surface.ComponentTest do
 
     test "render content with slot props" do
       code = """
-      <OuterWithSlotProps :let={{ info: my_info }}>
+      <OuterWithSlotProps :let={{ :info, as: :my_info }}>
         {{ @my_info }}
       </OuterWithSlotProps>
       """

--- a/test/components/form/inputs_test.exs
+++ b/test/components/form/inputs_test.exs
@@ -10,7 +10,7 @@ defmodule Surface.Components.Form.InputsTest do
   test "using generated form received as slot props" do
     code = """
     <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
-      <Inputs for={{ :children }} :let={{ form: f }}>
+      <Inputs for={{ :children }} :let={{ :form, as: :f }}>
         <TextInput form={{ @f }} field="name" />
         <TextInput form={{ @f }} field="email" />
       </Inputs>

--- a/test/components/form/inputs_test.exs
+++ b/test/components/form/inputs_test.exs
@@ -1,0 +1,69 @@
+defmodule Surface.Components.Form.InputsTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.Components.Form, warn: false
+  alias Surface.Components.Form.Inputs, warn: false
+  alias Surface.Components.Form.TextInput, warn: false
+
+  import ComponentTestHelper
+
+  test "using generated form received as slot props" do
+    code = """
+    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+      <Inputs for={{ :children }} :let={{ form: f }}>
+        <TextInput form={{ @f }} field="name" />
+        <TextInput form={{ @f }} field="email" />
+      </Inputs>
+    </Form>
+    """
+
+    assert render_live(code) =~ """
+           <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
+           <div>\
+           <input id="parent_children_name" name="parent[children][name]" type="text"/>\
+           <input id="parent_children_email" name="parent[children][email]" type="text"/>\
+           </div>\
+           </form>
+           """
+  end
+
+  test "using generated form stored in the Form context" do
+    code = """
+    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+      <Inputs for={{ :children }}>
+        <TextInput field="name" />
+        <TextInput field="email" />
+      </Inputs>
+    </Form>
+    """
+
+    assert render_live(code) =~ """
+           <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
+           <div>\
+           <input id="parent_children_name" name="parent[children][name]" type="text"/>\
+           <input id="parent_children_email" name="parent[children][email]" type="text"/>\
+           </div>\
+           </form>
+           """
+  end
+
+  test "passing extra opts" do
+    code = """
+    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+      <Inputs for={{ :children }} opts={{ as: "custom_name"}}>
+        <TextInput field="name" />
+        <TextInput field="email" />
+      </Inputs>
+    </Form>
+    """
+
+    assert render_live(code) =~ """
+           <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
+           <div>\
+           <input id="parent_children_name" name="custom_name[name]" type="text"/>\
+           <input id="parent_children_email" name="custom_name[email]" type="text"/>\
+           </div>\
+           </form>
+           """
+  end
+end

--- a/test/components/form/inputs_test.exs
+++ b/test/components/form/inputs_test.exs
@@ -19,10 +19,8 @@ defmodule Surface.Components.Form.InputsTest do
 
     assert render_live(code) =~ """
            <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
-           <div>\
            <input id="parent_children_name" name="parent[children][name]" type="text"/>\
            <input id="parent_children_email" name="parent[children][email]" type="text"/>\
-           </div>\
            </form>
            """
   end
@@ -39,10 +37,8 @@ defmodule Surface.Components.Form.InputsTest do
 
     assert render_live(code) =~ """
            <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
-           <div>\
            <input id="parent_children_name" name="parent[children][name]" type="text"/>\
            <input id="parent_children_email" name="parent[children][email]" type="text"/>\
-           </div>\
            </form>
            """
   end
@@ -59,10 +55,8 @@ defmodule Surface.Components.Form.InputsTest do
 
     assert render_live(code) =~ """
            <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
-           <div>\
            <input id="parent_children_name" name="custom_name[name]" type="text"/>\
            <input id="parent_children_email" name="custom_name[email]" type="text"/>\
-           </div>\
            </form>
            """
   end

--- a/test/live_component_test.exs
+++ b/test/live_component_test.exs
@@ -99,7 +99,7 @@ defmodule LiveComponentTest do
 
   test "render content with slot props" do
     code = """
-    <InfoProvider :let={{ info: my_info }}>
+    <InfoProvider :let={{ :info, as: :my_info }}>
       <span>{{ @my_info }}</span>
     </InfoProvider>
     """

--- a/test/slot_change_tracking_test.exs
+++ b/test/slot_change_tracking_test.exs
@@ -32,7 +32,7 @@ defmodule Surface.SlotChangeTrackingTest do
 
     def render(assigns) do
       ~H"""
-      <Outer id="outer" :let={{ param: param }}>
+      <Outer id="outer" :let={{ :param }}>
         Count: {{ @count }}
         <CheckUpdated id="1" dest={{ @test_pid }} content={{ @param }} />
         <CheckUpdated id="2" dest={{ @test_pid }} />

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -203,7 +203,7 @@ defmodule Surface.SlotTest do
   test "assign named slots with props" do
     code = """
     <OuterWithNamedSlotAndProps>
-      <template slot="body" :let={{ info: my_info }}>
+      <template slot="body" :let={{ :info, as: :my_info }}>
         Info: {{ @my_info }}
       </template>
     </OuterWithNamedSlotAndProps>
@@ -220,7 +220,7 @@ defmodule Surface.SlotTest do
 
   test "assign default slot with props" do
     code = """
-    <OuterWithDefaultSlotAndProps :let={{ info: my_info }}>
+    <OuterWithDefaultSlotAndProps :let={{ :info, as: :my_info }}>
       Info: {{ @my_info }}
     </OuterWithDefaultSlotAndProps>
     """
@@ -375,10 +375,10 @@ defmodule Surface.SlotTest do
 
     code = """
     <Grid items={{ user <- @items }}>
-      <Column title="ID" :let={{ item: my_user }}>
+      <Column title="ID" :let={{ :item, as: :my_user }}>
         <b>Id: {{ @my_user.id }}</b>
       </Column>
-      <Column title="NAME" :let={{ info: my_info }}>
+      <Column title="NAME" :let={{ :info, as: :my_info }}>
         Name: {{ @user.name }}
         Info: {{ @my_info }}
       </Column>
@@ -405,7 +405,7 @@ defmodule Surface.SlotTest do
 
     code = """
     <Grid items={{ user <- @items }}>
-      <Column title="ID" :let={{ item: my_user, non_existing: value}}>
+      <Column title="ID" :let={{ :item, as: :my_user }} :let={{ :non_existing, as: :value }}>
         <b>Id: {{ @my_user.id }}</b>
       </Column>
     </Grid>
@@ -430,15 +430,17 @@ defmodule Surface.SlotTest do
 
     code = """
     <OuterWithNamedSlotAndProps>
-      <template slot="body" :let={{ :an_atom }}>
+      <template slot="body"
+        :let={{ "a_string" }}>
         Info: {{ @my_info }}
       </template>
     </OuterWithNamedSlotAndProps>
     """
 
     message = """
-    code:2: invalid value for directive :let. \
-    Expected a keyword list of bindings, got: {{ :an_atom }}.\
+    code:3: invalid value for directive :let. \
+    Expected a mapping from a slot prop to an assign, \
+    e.g. {{ :item }} or {{ :item, as: :user }}, got: {{ "a_string" }}.\
     """
 
     assert_raise(CompileError, message, fn ->
@@ -448,7 +450,7 @@ defmodule Surface.SlotTest do
 
   test "raise compile error when using :let and there's no default slot defined" do
     code = """
-    <OuterWithoutDefaultSlot :let={{ info: my_info }}>
+    <OuterWithoutDefaultSlot :let={{ :info, as: :my_info }}>
       Info: {{ @my_info }}
     </OuterWithoutDefaultSlot>
     """
@@ -469,7 +471,7 @@ defmodule Surface.SlotTest do
 
   test "raise compile error when using :let with undefined props for default slot" do
     code = """
-    <OuterWithDefaultSlotAndProps :let={{ info: my_info, non_existing: value }}>
+    <OuterWithDefaultSlotAndProps :let={{ :info, as: :my_info }} :let={{ :non_existing, as: :value }}>
       Info: {{ @my_info }}
     </OuterWithDefaultSlotAndProps>
     """
@@ -489,16 +491,18 @@ defmodule Surface.SlotTest do
     end)
   end
 
-  test "raise compile error when using :let with invalid list of bindings" do
+  test "raise compile error when using :let with invalid binding" do
     code = """
-    <OuterWithDefaultSlotAndProps :let={{ info: 1 }}>
+    <OuterWithDefaultSlotAndProps
+      :let={{ info: 1 }}>
       Info: {{ @my_info }}
     </OuterWithDefaultSlotAndProps>
     """
 
     message = """
-    code:1: invalid value for directive :let. Expected a keyword \
-    list of bindings, got: {{ info: 1 }}.\
+    code:2: invalid value for directive :let. \
+    Expected a mapping from a slot prop to an assign, \
+    e.g. {{ :item }} or {{ :item, as: :user }}, got: {{ info: 1 }}.\
     """
 
     assert_raise(CompileError, message, fn ->
@@ -509,7 +513,7 @@ defmodule Surface.SlotTest do
   test "raise compile error when using :let with undefined slot props" do
     code = """
     <OuterWithNamedSlotAndProps>
-      <template slot="body" :let={{ non_existing: my_info }}>
+      <template slot="body" :let={{ :non_existing, as: :my_info }}>
         Info: {{ @my_info }}
       </template>
     </OuterWithNamedSlotAndProps>


### PR DESCRIPTION
A wrapper for `inputs_for/3`.

Related to #32.

### Usage with context

```jsx
<Form for={{ :parent }}>
  <Inputs for={{ :children }}>
    <TextInput field="name" />
    <TextInput field="email" />
  </Inputs>
</Form>
```

### Usage with slot props

```jsx
<Form for={{ :parent }}>
  <Inputs for={{ :children }} :let={{ form: f }}>
    <TextInput form={{ @f }} field="name" />
    <TextInput form={{ @f }} field="email" />
  </Inputs>
</Form>
```
