### PR TITLE
Add index and with_index modifiers to :for

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -586,6 +586,8 @@ defmodule Surface.Compiler do
   defp collect_directives(handlers, [attr | attributes], meta) do
     {:ok, dirs, attrs} = collect_directives(handlers, attributes, meta)
 
+    attr = extract_modifiers(attr)
+
     directives =
       handlers
       |> Enum.map(fn handler -> handler.extract(attr, meta) end)
@@ -604,6 +606,23 @@ defmodule Surface.Compiler do
       end)
 
     {:ok, directives, attributes}
+  end
+
+  defp extract_modifiers({":" <> _ = attr_name, value, meta}) do
+    {name, modifiers} =
+      case String.split(attr_name, ".") do
+        [name] ->
+          {name, []}
+
+        [name | modifiers] ->
+          {name, modifiers}
+      end
+
+    {name, value, Map.put(meta, :modifiers, modifiers)}
+  end
+
+  defp extract_modifiers(attr) do
+    attr
   end
 
   defp validate_properties(module, props, meta) do

--- a/lib/surface/directive/for.ex
+++ b/lib/surface/directive/for.ex
@@ -5,7 +5,7 @@ defmodule Surface.Directive.For do
     %AST.Directive{
       module: __MODULE__,
       name: :for,
-      value: directive_value(value, Helpers.to_meta(expr_meta, meta)),
+      value: directive_value(value, Helpers.to_meta(expr_meta, meta), attr_meta),
       meta: Helpers.to_meta(attr_meta, meta)
     }
   end
@@ -15,11 +15,62 @@ defmodule Surface.Directive.For do
   def process(%AST.Directive{value: %AST.AttributeExpr{} = expr, meta: meta}, node),
     do: %AST.For{generator: expr, children: [node], meta: meta}
 
-  defp directive_value(value, meta) do
+  defp directive_value(value, meta, attr_meta) do
+    quoted_value =
+      value
+      |> Surface.TypeHandler.expr_to_quoted!(":for", :generator, meta)
+      |> handle_modifiers(attr_meta.modifiers, %{line: attr_meta.line, file: meta.file})
+
     %AST.AttributeExpr{
       original: value,
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":for", :generator, meta),
+      value: quoted_value,
       meta: meta
     }
+  end
+
+  defp handle_modifiers([{:<-, clause_meta, [var, list]}], ["with_index" | modifiers], meta) do
+    udpated_list =
+      quote generated: true do
+        Enum.with_index(unquote(list))
+      end
+
+    handle_modifiers([{:<-, clause_meta, [var, udpated_list]}], modifiers, meta)
+  end
+
+  defp handle_modifiers([{:<-, clause_meta, [var, list]}], ["index" | modifiers], meta) do
+    udpated_list =
+      quote generated: true do
+        Enum.scan(unquote(list), -1, fn _, a -> a + 1 end)
+      end
+
+    handle_modifiers([{:<-, clause_meta, [var, udpated_list]}], modifiers, meta)
+  end
+
+  defp handle_modifiers([{_, clause_meta, _} = list], ["index" | modifiers], meta) do
+    var =
+      quote generated: true do
+        var!(index)
+      end
+
+    udpated_list =
+      quote generated: true do
+        Enum.scan(unquote(list), -1, fn _, a -> a + 1 end)
+      end
+
+    handle_modifiers([{:<-, clause_meta, [var, udpated_list]}], modifiers, meta)
+  end
+
+  defp handle_modifiers(clauses, [modifier | _modifiers], meta) when length(clauses) > 1 do
+    message = "cannot apply modifier \"#{modifier}\" on generators with multiple clauses"
+    IOHelper.compile_error(message, meta.file, meta.line)
+  end
+
+  defp handle_modifiers(_clauses, [modifier | _modifiers], meta) do
+    message = "unknown modifier \"#{modifier}\" for directive :for"
+    IOHelper.compile_error(message, meta.file, meta.line)
+  end
+
+  defp handle_modifiers(clauses, [], _meta) do
+    clauses
   end
 end

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -234,6 +234,98 @@ defmodule Surface.DirectivesTest do
              </div>
              """
     end
+
+    test "with_index modifier" do
+      assigns = %{items: [1, 2]}
+
+      code = """
+      <div :for.with_index={{ {item, index} <- @items }}>
+        Item: {{ item }}, Index: {{ index }}
+      </div>
+      """
+
+      assert render_live(code, assigns) =~ """
+             <div>
+               Item: 1, Index: 0
+             </div><div>
+               Item: 2, Index: 1
+             </div>
+             """
+    end
+
+    test "index modifier with generator" do
+      assigns = %{items: [1, 2]}
+
+      code = """
+      <div :for.index={{ index <- @items }}>
+        Index: {{ index }}
+      </div>
+      """
+
+      assert render_live(code, assigns) =~ """
+             <div>
+               Index: 0
+             </div><div>
+               Index: 1
+             </div>
+             """
+    end
+
+    test "index modifier with list" do
+      assigns = %{items: [1, 2]}
+
+      code = """
+      <div :for.index={{ @items }}>
+        Index: {{ index }}
+      </div>
+      """
+
+      assert render_live(code, assigns) =~ """
+             <div>
+               Index: 0
+             </div><div>
+               Index: 1
+             </div>
+             """
+    end
+
+    test "raise compile error for unknown modifiers" do
+      assigns = %{items: [%{id: 1, name: "First"}]}
+
+      code = """
+      <br/>
+      <div :for.unknown={{ @items }}>
+        Index: {{ index }}
+      </div>
+      """
+
+      message = """
+      code:2: unknown modifier "unknown" for directive :for\
+      """
+
+      assert_raise(CompileError, message, fn ->
+        render_live(code, assigns)
+      end)
+    end
+
+    test "raise compile error for modifiers with multiple clauses" do
+      assigns = %{a: [1, 2], b: [1, 2]}
+
+      code = """
+      <br/>
+      <div :for.with_index={{ i <- a, j <- b }}>
+        Index: {{ index }}
+      </div>
+      """
+
+      message = """
+      code:2: cannot apply modifier "with_index" on generators with multiple clauses\
+      """
+
+      assert_raise(CompileError, message, fn ->
+        render_live(code, assigns)
+      end)
+    end
   end
 
   describe ":if" do

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -156,6 +156,64 @@ defmodule Surface.DirectivesTest do
     end
   end
 
+  describe "modifiers" do
+    test "using multiple modifiers" do
+      assigns = %{items: [:a, :b]}
+
+      code = """
+      <div :for.index.with_index={{ {i, j} <- @items }}>
+        i: {{ i }}, j: {{ j }}
+      </div>
+      """
+
+      assert render_live(code, assigns) =~ """
+             <div>
+               i: 0, j: 0
+             </div><div>
+               i: 1, j: 1
+             </div>
+             """
+    end
+
+    test "raise compile error for unknown modifiers" do
+      assigns = %{items: [%{id: 1, name: "First"}]}
+
+      code = """
+      <br/>
+      <div :for.unknown={{ @items }}>
+        Index: {{ index }}
+      </div>
+      """
+
+      message = """
+      code:2: unknown modifier "unknown" for directive :for\
+      """
+
+      assert_raise(CompileError, message, fn ->
+        render_live(code, assigns)
+      end)
+    end
+
+    test "raise compile error for modifiers with multiple clauses" do
+      assigns = %{a: [1, 2], b: [1, 2]}
+
+      code = """
+      <br/>
+      <div :for.with_index={{ i <- a, j <- b }}>
+        Index: {{ index }}
+      </div>
+      """
+
+      message = """
+      code:2: cannot apply modifier "with_index" on generators with multiple clauses\
+      """
+
+      assert_raise(CompileError, message, fn ->
+        render_live(code, assigns)
+      end)
+    end
+  end
+
   describe ":for" do
     test "in components" do
       assigns = %{items: [1, 2]}
@@ -287,44 +345,6 @@ defmodule Surface.DirectivesTest do
                Index: 1
              </div>
              """
-    end
-
-    test "raise compile error for unknown modifiers" do
-      assigns = %{items: [%{id: 1, name: "First"}]}
-
-      code = """
-      <br/>
-      <div :for.unknown={{ @items }}>
-        Index: {{ index }}
-      </div>
-      """
-
-      message = """
-      code:2: unknown modifier "unknown" for directive :for\
-      """
-
-      assert_raise(CompileError, message, fn ->
-        render_live(code, assigns)
-      end)
-    end
-
-    test "raise compile error for modifiers with multiple clauses" do
-      assigns = %{a: [1, 2], b: [1, 2]}
-
-      code = """
-      <br/>
-      <div :for.with_index={{ i <- a, j <- b }}>
-        Index: {{ index }}
-      </div>
-      """
-
-      message = """
-      code:2: cannot apply modifier "with_index" on generators with multiple clauses\
-      """
-
-      assert_raise(CompileError, message, fn ->
-        render_live(code, assigns)
-      end)
     end
   end
 


### PR DESCRIPTION
This PR adds initial support for modifiers. Two modifiers were added to the `:for` directive, which are `with_index` and `index`.

## Examples

### .index

```jsx
<td :for={{ {_col, index} <- Enum.with_index(@cols) }}>
  <slot name="cols" index={{ index }}/>
</td>
``` 

can be written as:

```jsx
<td :for.index={{ @cols }}>
  <slot name="cols" index={{ index }}/>
</td>
``` 

or

```jsx
<td :for.index={{ i <- @cols }}>
  <slot name="cols" index={{ i }}/>
</td>
``` 

### .with_index

```jsx
<td :for={{ {item, index} <- Enum.with_index(@items) }}>
  Title: {{ item.title }}
  Content: <slot name="cols" index={{ index }}/>
</td>
```
can be written as:

```jsx
<td :for.with_index={{ {item, index} <- @items }}>
  Title: {{ item.title }}
  Content: <slot name="cols" index={{ index }}/>
</td>
```

## Using multiple modifiers

Currently we only have `index` and `with_index` but in the near future we could add a few more. This way we could use them together, for instance:

```jsx
<td :for.compact.uniq.with_index={{ {item, index} <- @items }}>
  Title: {{ item.title }}
  Content: <slot name="cols" index={{ index }}/>
</td>
```

would be equivalent to:

```jsx
<td :for={{ {item, index} <- @items |> Enum.reject(&is_nil/1) |> Enum.uniq() |> Enum.with_index() }}>
  Title: {{ item.title }}
  Content: <slot name="cols" index={{ index }}/>
</td>
```

