### PR TITLE
Select component

### DIFF
--- a/lib/surface/components/form/select.ex
+++ b/lib/surface/components/form/select.ex
@@ -1,0 +1,45 @@
+defmodule Surface.Components.Form.Select do
+  @moduledoc """
+  Defines a select.
+
+  Provides a wrapper for Phoenix.HTML.Form's `select/4` function.
+
+  All options passed via `opts` will be sent to `select/4`, `class` can
+  be set directly and will override anything in `opts`.
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form, only: [select: 4]
+  import Surface.Components.Form.Utils
+
+  @doc "The form identifier"
+  property form, :form
+
+  @doc "The field name"
+  property field, :string
+
+  @doc "The CSS class for the underlying tag"
+  property class, :css_class
+
+  @doc "The options in the select"
+  property options, :keyword, default: []
+
+  @doc "Options list"
+  property opts, :keyword, default: []
+
+  @doc """
+  The content for the label
+  """
+  slot default
+
+  def render(assigns) do
+    form = get_form(assigns)
+    field = get_field(assigns)
+    props = get_non_nil_props(assigns, class: get_config(:default_class))
+
+    ~H"""
+    {{ select(form, field, @options, props ++ @opts) }}
+    """
+  end
+end

--- a/test/components/form/select_test.exs
+++ b/test/components/form/select_test.exs
@@ -1,0 +1,60 @@
+defmodule Surface.Components.Form.SelectTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.Components.Form.Select, warn: false
+
+  import ComponentTestHelper
+
+  test "select" do
+    code = """
+    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} />
+    """
+
+    assert render_live(code) =~ """
+           <select id="user_role" name="user[role]"><option value="admin">Admin</option><option value="user">User</option></select>
+           """
+  end
+
+  test "setting the class" do
+    code = """
+    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} class="select" />
+    """
+
+    assert render_live(code) =~ ~r/class="select"/
+  end
+
+  test "setting multiple classes" do
+    code = """
+    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} class="select primary" />
+    """
+
+    assert render_live(code) =~ ~r/class="select primary"/
+  end
+
+  test "passing other options" do
+    code = """
+    <Select form="user" field="role" opts={{ prompt: "Pick a role" }} />
+    """
+
+    assert render_live(code) =~ """
+           <select id="user_role" name="user[role]"><option value="">Pick a role</option></select>
+           """
+  end
+end
+
+defmodule Surface.Components.Form.SelectConfigTest do
+  use ExUnit.Case
+
+  alias Surface.Components.Form.Select, warn: false
+  import ComponentTestHelper
+
+  test ":default_class config" do
+    using_config Select, default_class: "default_class" do
+      code = """
+      <Select />
+      """
+
+      assert render_live(code) =~ ~r/class="default_class"/
+    end
+  end
+end


### PR DESCRIPTION
A wrapper for `select/4`.

Related to #32.

### Example
```Elixir
<Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} />
```

### Example with context
```Elixir
<Form for={{ :form }}>
  <Field name={{ :role }}>
    <Select options={{ ["Admin": "admin", "User": "user"] }} />
  </Field>
</Form>
```