### PR TITLE
MultipleSelect component

### DIFF
--- a/lib/surface/components/form/multiple_select.ex
+++ b/lib/surface/components/form/multiple_select.ex
@@ -23,7 +23,7 @@ defmodule Surface.Components.Form.MultipleSelect do
   property class, :css_class
 
   @doc "The options in the select"
-  property options, :keyword, default: []
+  property options, :any, default: []
 
   @doc "Options list"
   property opts, :keyword, default: []

--- a/lib/surface/components/form/multiple_select.ex
+++ b/lib/surface/components/form/multiple_select.ex
@@ -1,0 +1,45 @@
+defmodule Surface.Components.Form.MultipleSelect do
+  @moduledoc """
+  Defines a select.
+
+  Provides a wrapper for Phoenix.HTML.Form's `multiple_select/4` function.
+
+  All options passed via `opts` will be sent to `multiple_select/4`, `class` can
+  be set directly and will override anything in `opts`.
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form, only: [multiple_select: 4]
+  import Surface.Components.Form.Utils
+
+  @doc "The form identifier"
+  property form, :form
+
+  @doc "The field name"
+  property field, :string
+
+  @doc "The CSS class for the underlying tag"
+  property class, :css_class
+
+  @doc "The options in the select"
+  property options, :keyword, default: []
+
+  @doc "Options list"
+  property opts, :keyword, default: []
+
+  @doc """
+  The content for the label
+  """
+  slot default
+
+  def render(assigns) do
+    form = get_form(assigns)
+    field = get_field(assigns)
+    props = get_non_nil_props(assigns, class: get_config(:default_class))
+
+    ~H"""
+    {{ multiple_select(form, field, @options, props ++ @opts) }}
+    """
+  end
+end

--- a/lib/surface/components/form/select.ex
+++ b/lib/surface/components/form/select.ex
@@ -23,7 +23,7 @@ defmodule Surface.Components.Form.Select do
   property class, :css_class
 
   @doc "The options in the select"
-  property options, :keyword, default: []
+  property options, :any, default: []
 
   @doc "Options list"
   property opts, :keyword, default: []

--- a/lib/surface/type_handler/default.ex
+++ b/lib/surface/type_handler/default.ex
@@ -30,6 +30,10 @@ defmodule Surface.TypeHandler.Default do
     {:ok, value}
   end
 
+  def expr_to_value([], opts) do
+    {:ok, opts}
+  end
+
   def expr_to_value(clauses, opts) do
     {:error, clauses ++ opts}
   end

--- a/test/components/form/multiple_select.ex
+++ b/test/components/form/multiple_select.ex
@@ -1,0 +1,60 @@
+defmodule Surface.Components.Form.MultipleSelectTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.Components.Form.MultipleSelect, warn: false
+
+  import ComponentTestHelper
+
+  test "select" do
+    code = """
+    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} />
+    """
+
+    assert render_live(code) =~ """
+           <select id="user_roles" multiple="" name="user[roles][]"><option value="admin">Admin</option><option value="user">User</option></select>
+           """
+  end
+
+  test "setting the class" do
+    code = """
+    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} class="select" />
+    """
+
+    assert render_live(code) =~ ~r/class="select"/
+  end
+
+  test "setting multiple classes" do
+    code = """
+    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} class="select primary" />
+    """
+
+    assert render_live(code) =~ ~r/class="select primary"/
+  end
+
+  test "passing other options" do
+    code = """
+    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} opts={{ selected: ["admin"] }} />
+    """
+
+    assert render_live(code) =~ """
+           <select id="user_roles" multiple="" name="user[roles][]"><option value="admin" selected="selected">Admin</option><option value="user">User</option></select>
+           """
+  end
+end
+
+defmodule Surface.Components.Form.MultipleSelectConfigTest do
+  use ExUnit.Case
+
+  alias Surface.Components.Form.MultipleSelect, warn: false
+  import ComponentTestHelper
+
+  test ":default_class config" do
+    using_config MultipleSelect, default_class: "default_class" do
+      code = """
+      <MultipleSelect />
+      """
+
+      assert render_live(code) =~ ~r/class="default_class"/
+    end
+  end
+end

--- a/test/components/form/select_test.exs
+++ b/test/components/form/select_test.exs
@@ -33,11 +33,11 @@ defmodule Surface.Components.Form.SelectTest do
 
   test "passing other options" do
     code = """
-    <Select form="user" field="role" opts={{ prompt: "Pick a role" }} />
+    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} opts={{ prompt: "Pick a role" }} />
     """
 
     assert render_live(code) =~ """
-           <select id="user_role" name="user[role]"><option value="">Pick a role</option></select>
+           <select id="user_role" name="user[role]"><option value="">Pick a role</option><option value="admin">Admin</option><option value="user">User</option></select>
            """
   end
 end


### PR DESCRIPTION
A wrapper for `multiple_select/4`.

Related to #32.

### Example
```Elixir
<MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} />
```

### Example with context
```Elixir
<Form for={{ :form }}>
  <Field name={{ :roles }}>
    <MultipleSelect options={{ ["Admin": "admin", "User": "user"] }} />
  </Field>
</Form>
```