### PR TITLE
HiddenInputs component

### DIFF
--- a/lib/surface/components/form/hidden_inputs.ex
+++ b/lib/surface/components/form/hidden_inputs.ex
@@ -1,0 +1,27 @@
+defmodule Surface.Components.Form.HiddenInputs do
+  @moduledoc """
+  A wrapper for `Phoenix.HTML.Form.html.hidden_inputs_for/1`.
+
+  Generates hidden inputs for the given form.
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form
+  import Surface.Components.Form.Utils
+
+  @doc """
+  The form.
+
+  It should either be a `Phoenix.HTML.Form` emitted by `form_for`, `inputs_for` or an atom.
+  """
+  property for, :form
+
+  def render(assigns) do
+    form = get_form(assigns)
+
+    ~H"""
+    {{ hidden_inputs_for(form) }}
+    """
+  end
+end

--- a/test/components/form/hidden_inputs_for_test.exs
+++ b/test/components/form/hidden_inputs_for_test.exs
@@ -1,0 +1,41 @@
+defmodule Surface.Components.Form.HiddenInputsTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.Components.Form, warn: false
+  alias Surface.Components.Form.Inputs, warn: false
+  alias Surface.Components.Form.HiddenInputs, warn: false
+
+  import ComponentTestHelper
+
+  test "using generated form received as slot props" do
+    code = """
+    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+      <Inputs for={{ :children }} :let={{ :form, as: :f }}>
+        <HiddenInputs for={{ @f }} />
+      </Inputs>
+    </Form>
+    """
+
+    assert render_live(code) =~ """
+           <form action="#" method="post">\
+           <input name="_csrf_token" type="hidden" value="test"/>\
+           </form>
+           """
+  end
+
+  test "using generated form stored in the Form context" do
+    code = """
+    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+      <Inputs for={{ :children }}>
+        <HiddenInputs />
+      </Inputs>
+    </Form>
+    """
+
+    assert render_live(code) =~ """
+           <form action="#" method="post">\
+           <input name="_csrf_token" type="hidden" value="test"/>\
+           </form>
+           """
+  end
+end

--- a/test/components/form/multiple_select_test.exs
+++ b/test/components/form/multiple_select_test.exs
@@ -5,13 +5,26 @@ defmodule Surface.Components.Form.MultipleSelectTest do
 
   import ComponentTestHelper
 
-  test "select" do
+  test "emtpy multiple select" do
+    code = """
+    <MultipleSelect form="user" field="roles" />
+    """
+
+    assert render_live(code) =~ """
+           <select id="user_roles" multiple="" name="user[roles][]"></select>
+           """
+  end
+
+  test "setting the options" do
     code = """
     <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} />
     """
 
     assert render_live(code) =~ """
-           <select id="user_roles" multiple="" name="user[roles][]"><option value="admin">Admin</option><option value="user">User</option></select>
+           <select id="user_roles" multiple="" name="user[roles][]">\
+           <option value="admin">Admin</option>\
+           <option value="user">User</option>\
+           </select>
            """
   end
 
@@ -37,7 +50,10 @@ defmodule Surface.Components.Form.MultipleSelectTest do
     """
 
     assert render_live(code) =~ """
-           <select id="user_roles" multiple="" name="user[roles][]"><option value="admin" selected="selected">Admin</option><option value="user">User</option></select>
+           <select id="user_roles" multiple="" name="user[roles][]">\
+           <option value="admin" selected="selected">Admin</option>\
+           <option value="user">User</option>\
+           </select>
            """
   end
 end

--- a/test/components/form/options_for_select_test.exs
+++ b/test/components/form/options_for_select_test.exs
@@ -5,13 +5,22 @@ defmodule Surface.Components.Form.OptionsForSelectTest do
 
   import ComponentTestHelper
 
-  test "select" do
+  test "empty options" do
+    code = """
+    <OptionsForSelect />
+    """
+
+    assert render_live(code) == "\n"
+  end
+
+  test "setting the options" do
     code = """
     <OptionsForSelect options={{ ["Admin": "admin", "User": "user"] }} />
     """
 
     assert render_live(code) =~ """
-           <option value="admin">Admin</option><option value="user">User</option>
+           <option value="admin">Admin</option>\
+           <option value="user">User</option>
            """
   end
 
@@ -21,7 +30,8 @@ defmodule Surface.Components.Form.OptionsForSelectTest do
     """
 
     assert render_live(code) =~ """
-           <option value="admin" selected="selected">Admin</option><option value="user">User</option>
+           <option value="admin" selected="selected">Admin</option>\
+           <option value="user">User</option>
            """
   end
 
@@ -31,7 +41,8 @@ defmodule Surface.Components.Form.OptionsForSelectTest do
     """
 
     assert render_live(code) =~ """
-           <option value="admin" selected="selected">Admin</option><option value="user" selected="selected">User</option>
+           <option value="admin" selected="selected">Admin</option>\
+           <option value="user" selected="selected">User</option>
            """
   end
 end

--- a/test/components/form/select_test.exs
+++ b/test/components/form/select_test.exs
@@ -5,13 +5,26 @@ defmodule Surface.Components.Form.SelectTest do
 
   import ComponentTestHelper
 
-  test "select" do
+  test "empty select" do
+    code = """
+    <Select form="user" field="role" />
+    """
+
+    assert render_live(code) =~ """
+           <select id="user_role" name="user[role]"></select>
+           """
+  end
+
+  test "setting the options" do
     code = """
     <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} />
     """
 
     assert render_live(code) =~ """
-           <select id="user_role" name="user[role]"><option value="admin">Admin</option><option value="user">User</option></select>
+           <select id="user_role" name="user[role]">\
+           <option value="admin">Admin</option>\
+           <option value="user">User</option>\
+           </select>
            """
   end
 
@@ -37,7 +50,11 @@ defmodule Surface.Components.Form.SelectTest do
     """
 
     assert render_live(code) =~ """
-           <select id="user_role" name="user[role]"><option value="">Pick a role</option><option value="admin">Admin</option><option value="user">User</option></select>
+           <select id="user_role" name="user[role]">\
+           <option value="">Pick a role</option>\
+           <option value="admin">Admin</option>\
+           <option value="user">User</option>\
+           </select>
            """
   end
 end


### PR DESCRIPTION
A wrapper for `hidden_inputs_for/1`.

I chose the name `<HiddenInputs for={{...}} .../>` to stay consistent with `<Form for={{...}} .../>` and `<Inputs for={{...}} .../>`

Related to #32.

### Example with slot props
```Elixir
<Form for={{ :parent }}>
  <Inputs for={{ :children }} :let={{ :form, as: :f }}>
    <HiddenInputs for={{ @f }} />
  </Inputs>
</Form>
```

### Example with context
```Elixir
<Form for={{ :parent }}>
  <Inputs for={{ :children }}>
    <HiddenInputs />
  </Inputs>
</Form>
```