### PR TITLE
utilize slot props to define context variables

### DIFF
--- a/lib/surface/type_handler/context_get.ex
+++ b/lib/surface/type_handler/context_get.ex
@@ -34,6 +34,11 @@ defmodule Surface.TypeHandler.ContextGet do
     {:error, @error_message}
   end
 
+  @impl true
+  def update_prop_expr({scope, values}, _meta) do
+    {scope, Enum.map(values, fn {key, {name, _, _}} -> {key, name} end)}
+  end
+
   defp is_scope?(scope) do
     is_atom(scope) or
       match?({:__aliases__, _, _}, scope) or


### PR DESCRIPTION
After looking at your current PR, I thought we might be able to take advantage of the slop props to define context variables instead of injecting `var = value` statements. Some of the code in the context class would need to be cleaned up, but the basic idea does work.

WDYT?