### PR TITLE
fix directives using Map.merge instead of Helpers.to_meta

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -676,8 +676,7 @@ defmodule Surface.Compiler do
             `slot #{slot_name}, props: [..., #{inspect(prop)}]`\
             """
 
-            line = prop_meta.line + prop_meta.line_offset - 1
-            IOHelper.compile_error(message, prop_meta.file, line)
+            IOHelper.compile_error(message, prop_meta.file, prop_meta.line)
           end
 
         _ ->

--- a/lib/surface/directive/debug.ex
+++ b/lib/surface/directive/debug.ex
@@ -5,7 +5,7 @@ defmodule Surface.Directive.Debug do
     %AST.Directive{
       module: __MODULE__,
       name: :debug,
-      value: directive_value(value, Map.merge(meta, expr_meta)),
+      value: directive_value(value, Helpers.to_meta(expr_meta, meta)),
       meta: Helpers.to_meta(attr_meta, meta)
     }
   end

--- a/lib/surface/directive/let.ex
+++ b/lib/surface/directive/let.ex
@@ -5,8 +5,8 @@ defmodule Surface.Directive.Let do
     %AST.Directive{
       module: __MODULE__,
       name: :let,
-      value: directive_value(value, Map.merge(meta, expr_meta)),
-      meta: Map.merge(meta, attr_meta)
+      value: directive_value(value, Helpers.to_meta(expr_meta, meta)),
+      meta: Helpers.to_meta(attr_meta, meta)
     }
   end
 


### PR DESCRIPTION
A few of the directives were just calling `Map.merge` instead of `Helpers.to_meta` which handles updating the line number based on the offset