### PR TITLE
DateTimeSelect component

### DIFF
--- a/lib/surface/components/form/datetime_select.ex
+++ b/lib/surface/components/form/datetime_select.ex
@@ -4,8 +4,8 @@ defmodule Surface.Components.Form.DateTimeSelect do
 
   Provides a wrapper for Phoenix.HTML.Form's `datetime_select/3` function.
 
-  All options passed via `opts` will be sent to `datetime_select/3`, `value` and
-  `class` can be set directly and will override anything in `opts`.
+  All options passed via `opts` will be sent to `datetime_select/3`, `value`
+  can be set directly and will override anything in `opts`.
 
 
   ## Examples

--- a/lib/surface/components/form/datetime_select.ex
+++ b/lib/surface/components/form/datetime_select.ex
@@ -14,7 +14,7 @@ defmodule Surface.Components.Form.DateTimeSelect do
   <DateTimeSelect form="user" field="born_at" />
 
   <Form for={{ :user }}>
-    <FileInput field={{ :born_at }} />
+    <DateTimeSelect field={{ :born_at }} />
   </Form>
   ```
   """

--- a/lib/surface/components/form/datetime_select.ex
+++ b/lib/surface/components/form/datetime_select.ex
@@ -1,0 +1,49 @@
+defmodule Surface.Components.Form.DateTimeSelect do
+  @moduledoc """
+  Generates select tags for datetime.
+
+  Provides a wrapper for Phoenix.HTML.Form's `datetime_select/3` function.
+
+  All options passed via `opts` will be sent to `datetime_select/3`, `value` and
+  `class` can be set directly and will override anything in `opts`.
+
+
+  ## Examples
+
+  ```
+  <DateTimeSelect form="user" field="born_at" />
+
+  <Form for={{ :user }}>
+    <FileInput field={{ :born_at }} />
+  </Form>
+  ```
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form, only: [datetime_select: 3]
+  import Surface.Components.Form.Utils
+  alias Surface.Components.Form.Input.InputContext
+
+  @doc "The form identifier"
+  prop form, :form
+
+  @doc "The field name"
+  prop field, :string
+
+  @doc "Value to pre-populated the select"
+  prop value, :any
+
+  @doc "Options list"
+  prop opts, :keyword, default: []
+
+  def render(assigns) do
+    props = get_non_nil_props(assigns, [:value])
+
+    ~H"""
+    <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
+      {{ datetime_select(form, field, props ++ @opts) }}
+    </InputContext>
+    """
+  end
+end

--- a/lib/surface/components/form/datetime_select.ex
+++ b/lib/surface/components/form/datetime_select.ex
@@ -22,7 +22,6 @@ defmodule Surface.Components.Form.DateTimeSelect do
   use Surface.Component
 
   import Phoenix.HTML.Form, only: [datetime_select: 3]
-  import Surface.Components.Form.Utils
   alias Surface.Components.Form.Input.InputContext
 
   @doc "The form identifier"
@@ -31,14 +30,18 @@ defmodule Surface.Components.Form.DateTimeSelect do
   @doc "The field name"
   prop field, :string
 
-  @doc "Value to pre-populated the select"
+  @doc "Value to pre-populate the select"
   prop value, :any
 
   @doc "Options list"
   prop opts, :keyword, default: []
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value])
+    props =
+      case assigns[:value] do
+        nil -> []
+        value -> [value: value]
+      end
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>

--- a/test/components/form/datetime_select_test.exs
+++ b/test/components/form/datetime_select_test.exs
@@ -38,32 +38,32 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
 
   test "setting the value as map" do
     code = """
-    <DateTimeSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} />
+    <DateTimeSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
     """
 
     content = render_live(code)
 
-    assert content =~ ~s(<option value="2020" selected>2020</option>)
-    assert content =~ ~s(<option value="10" selected>October</option>)
-    assert content =~ ~s(<option value="9" selected>09</option>)
-    assert content =~ ~s(<option value="2" selected>02</option>)
-    assert content =~ ~s(<option value="11" selected>11</option>)
-    assert content =~ ~s(<option value="13" selected>13</option>)
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
   end
 
   test "setting the value as tuple" do
     code = """
-    <DateTimeSelect form="user" field="born_at" value={{ { {2020, 10, 9}, {2, 11, 13} } }} />
+    <DateTimeSelect form="user" field="born_at" value={{ { {2020, 10, 9}, {2, 11, 13} } }} opts={{ second: [] }} />
     """
 
     content = render_live(code)
 
-    assert content =~ ~s(<option value="2020" selected>2020</option>)
-    assert content =~ ~s(<option value="10" selected>October</option>)
-    assert content =~ ~s(<option value="9" selected>09</option>)
-    assert content =~ ~s(<option value="2" selected>02</option>)
-    assert content =~ ~s(<option value="11" selected>11</option>)
-    assert content =~ ~s(<option value="13" selected>13</option>)
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
   end
 
   test "passing other options" do

--- a/test/components/form/datetime_select_test.exs
+++ b/test/components/form/datetime_select_test.exs
@@ -1,0 +1,83 @@
+defmodule Surface.Components.Form.DateTimeSelectTest do
+  use ExUnit.Case, async: true
+
+  import ComponentTestHelper
+  alias Surface.Components.Form, warn: false
+  alias Surface.Components.Form.DateTimeSelect, warn: false
+
+  test "datetime select" do
+    code = """
+    <DateTimeSelect form="user" field="born_at" />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<select id="user_born_at_year" name="user[born_at][year]">)
+    assert content =~ ~s(<select id="user_born_at_month" name="user[born_at][month]">)
+    assert content =~ ~s(<select id="user_born_at_day" name="user[born_at][day]">)
+    assert content =~ ~s(<select id="user_born_at_hour" name="user[born_at][hour]">)
+    assert content =~ ~s(<select id="user_born_at_minute" name="user[born_at][minute]">)
+  end
+
+  test "with form context" do
+    code = """
+    <Form for={{ :user }}>
+      <DateTimeSelect field={{ :born_at }} />
+    </Form>
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<form action="#" method="post">)
+    assert content =~ ~s(<select id="user_born_at_year" name="user[born_at][year]">)
+    assert content =~ ~s(<select id="user_born_at_month" name="user[born_at][month]">)
+    assert content =~ ~s(<select id="user_born_at_day" name="user[born_at][day]">)
+    assert content =~ ~s(<select id="user_born_at_hour" name="user[born_at][hour]">)
+    assert content =~ ~s(<select id="user_born_at_minute" name="user[born_at][minute]">)
+  end
+
+  test "setting the value as map" do
+    code = """
+    <DateTimeSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2020" selected>2020</option>)
+    assert content =~ ~s(<option value="10" selected>October</option>)
+    assert content =~ ~s(<option value="9" selected>09</option>)
+    assert content =~ ~s(<option value="2" selected>02</option>)
+    assert content =~ ~s(<option value="11" selected>11</option>)
+    assert content =~ ~s(<option value="13" selected>13</option>)
+  end
+
+  test "setting the value as tuple" do
+    code = """
+    <DateTimeSelect form="user" field="born_at" value={{ { {2020, 10, 9}, {2, 11, 13} } }} />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2020" selected>2020</option>)
+    assert content =~ ~s(<option value="10" selected>October</option>)
+    assert content =~ ~s(<option value="9" selected>09</option>)
+    assert content =~ ~s(<option value="2" selected>02</option>)
+    assert content =~ ~s(<option value="11" selected>11</option>)
+    assert content =~ ~s(<option value="13" selected>13</option>)
+  end
+
+  test "passing other options" do
+    code = """
+    <DateTimeSelect form="user" field="born_at" opts={{ second: [] }} />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<select id="user_born_at_year" name="user[born_at][year]">)
+    assert content =~ ~s(<select id="user_born_at_month" name="user[born_at][month]">)
+    assert content =~ ~s(<select id="user_born_at_day" name="user[born_at][day]">)
+    assert content =~ ~s(<select id="user_born_at_hour" name="user[born_at][hour]">)
+    assert content =~ ~s(<select id="user_born_at_minute" name="user[born_at][minute]">)
+    assert content =~ ~s(<select id="user_born_at_second" name="user[born_at][second]">)
+  end
+end


### PR DESCRIPTION
A wrapper for `datetime_select/3`.

Related to #32.

### Example
```Elixir
<DateTimeSelect form="user" field="born_at" />
```

### Example with context
```Elixir
<Form for={{ :user }}>
  <DateTimeSelect field={{ :born_at }} />
</Form>
```