### PR TITLE
TimeSelect component

### DIFF
--- a/lib/surface/components/form/time_select.ex
+++ b/lib/surface/components/form/time_select.ex
@@ -4,8 +4,8 @@ defmodule Surface.Components.Form.TimeSelect do
 
   Provides a wrapper for Phoenix.HTML.Form's `time_select/3` function.
 
-  All options passed via `opts` will be sent to `time_select/3`, `value` and
-  `class` can be set directly and will override anything in `opts`.
+  All options passed via `opts` will be sent to `time_select/3`, `value` can be
+  set directly and will override anything in `opts`.
 
 
   ## Examples

--- a/lib/surface/components/form/time_select.ex
+++ b/lib/surface/components/form/time_select.ex
@@ -1,0 +1,52 @@
+defmodule Surface.Components.Form.TimeSelect do
+  @moduledoc """
+  Generates select tags for time.
+
+  Provides a wrapper for Phoenix.HTML.Form's `time_select/3` function.
+
+  All options passed via `opts` will be sent to `time_select/3`, `value` and
+  `class` can be set directly and will override anything in `opts`.
+
+
+  ## Examples
+
+  ```
+  <TimeSelect form="alarm" field="time" />
+
+  <Form for={{ :alarm }}>
+    <TimeSelect field={{ :time }} />
+  </Form>
+  ```
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form, only: [time_select: 3]
+  alias Surface.Components.Form.Input.InputContext
+
+  @doc "The form identifier"
+  prop form, :form
+
+  @doc "The field name"
+  prop field, :string
+
+  @doc "Value to pre-populate the select"
+  prop value, :any
+
+  @doc "Options list"
+  prop opts, :keyword, default: []
+
+  def render(assigns) do
+    props =
+      case assigns[:value] do
+        nil -> []
+        value -> [value: value]
+      end
+
+    ~H"""
+    <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
+      {{ time_select(form, field, props ++ @opts) }}
+    </InputContext>
+    """
+  end
+end

--- a/test/components/form/time_select_test.exs
+++ b/test/components/form/time_select_test.exs
@@ -1,0 +1,68 @@
+defmodule Surface.Components.Form.TimeSelectTest do
+  use ExUnit.Case, async: true
+
+  import ComponentTestHelper
+  alias Surface.Components.Form, warn: false
+  alias Surface.Components.Form.TimeSelect, warn: false
+
+  test "datetime select" do
+    code = """
+    <TimeSelect form="alarm" field="time" />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<select id="alarm_time_hour" name="alarm[time][hour]">)
+    assert content =~ ~s(<select id="alarm_time_minute" name="alarm[time][minute]">)
+  end
+
+  test "with form context" do
+    code = """
+    <Form for={{ :alarm }}>
+      <TimeSelect field={{ :time }} />
+    </Form>
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<form action="#" method="post">)
+    assert content =~ ~s(<select id="alarm_time_hour" name="alarm[time][hour]">)
+    assert content =~ ~s(<select id="alarm_time_minute" name="alarm[time][minute]">)
+  end
+
+  test "setting the value as map" do
+    code = """
+    <TimeSelect form="alarm" field="time" value={{ %{hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
+  end
+
+  test "setting the value as tuple" do
+    code = """
+    <TimeSelect form="alarm" field="time" value={{ {2, 11, 13} }} opts={{ second: [] }} />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
+  end
+
+  test "passing other options" do
+    code = """
+    <TimeSelect form="alarm" field="time" opts={{ second: [] }} />
+    """
+
+    content = render_live(code)
+
+    assert content =~ ~s(<select id="alarm_time_hour" name="alarm[time][hour]">)
+    assert content =~ ~s(<select id="alarm_time_minute" name="alarm[time][minute]">)
+    assert content =~ ~s(<select id="alarm_time_second" name="alarm[time][second]">)
+  end
+end


### PR DESCRIPTION
A wrapper for `time_select/3`.

Related to #32.

### Example
```Elixir
<TimeSelect form="alarm" field="time" />
```

### Example with context
```Elixir
<Form for={{ :alarm }}>
  <TimeSelect field={{ :time }} />
</Form>
```