### PR TITLE
add warnings for undefined assigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Update liveview to latest v0.15-dev (597c5dd)
     * render_live -> render_block
     * @inner_content -> @inner_block
+  * Add undefined assign check for `Surface.{LiveComponent,Component,LiveView}`
 
 ## v0.1.0-rc.0 (2020-10-06)
 

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -105,8 +105,14 @@ defmodule Surface do
     # not for ~H* variants. See https://github.com/msaraiva/surface/issues/15#issuecomment-667305899
     line_offset = __CALLER__.line + 1
 
+    caller_is_surface_component =
+      Module.open?(__CALLER__.module) &&
+        Module.get_attribute(__CALLER__.module, :component_type) != nil
+
     string
-    |> Surface.Compiler.compile(line_offset, __CALLER__, __CALLER__.file)
+    |> Surface.Compiler.compile(line_offset, __CALLER__, __CALLER__.file,
+      checks: [no_undefined_assigns: caller_is_surface_component]
+    )
     |> Surface.Compiler.to_live_struct(
       debug: Enum.member?(opts, ?d),
       file: __CALLER__.file,

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -135,7 +135,8 @@ defmodule Surface.API do
   def get_assigns(module) do
     if Module.open?(module) do
       module
-      |> Module.get_attribute(:assigns, %{})
+      |> Module.get_attribute(:assigns)
+      |> Kernel.||(%{})
       |> Map.keys()
     else
       data = if function_exported?(module, :__data__, 0), do: module.data(), else: []

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -132,6 +132,20 @@ defmodule Surface.API do
     Module.put_attribute(caller.module, assign.func, assign)
   end
 
+  def get_assigns(module) do
+    if Module.open?(module) do
+      module
+      |> Module.get_attribute(:assigns, %{})
+      |> Map.keys()
+    else
+      data = if function_exported?(module, :__data__, 0), do: module.data(), else: []
+      props = if function_exported?(module, :__props__, 0), do: module.props(), else: []
+      slots = if function_exported?(module, :__slots__, 0), do: module.slots(), else: []
+
+      Enum.map(data ++ props ++ slots, fn %{name: name} -> name end)
+    end
+  end
+
   @doc false
   def get_slots(module) do
     used_slots =

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -137,13 +137,13 @@ defmodule Surface.API do
       module
       |> Module.get_attribute(:assigns)
       |> Kernel.||(%{})
-      |> Map.keys()
+      |> Enum.map(fn {name, %{line: line}} -> {name, line} end)
     else
       data = if function_exported?(module, :__data__, 0), do: module.__data__(), else: []
       props = if function_exported?(module, :__props__, 0), do: module.__props__(), else: []
       slots = if function_exported?(module, :__slots__, 0), do: module.__slots__(), else: []
 
-      Enum.map(data ++ props ++ slots, fn %{name: name} -> name end)
+      Enum.map(data ++ props ++ slots, fn %{name: name, line: line} -> {name, line} end)
     end
   end
 

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -139,9 +139,9 @@ defmodule Surface.API do
       |> Kernel.||(%{})
       |> Map.keys()
     else
-      data = if function_exported?(module, :__data__, 0), do: module.data(), else: []
-      props = if function_exported?(module, :__props__, 0), do: module.props(), else: []
-      slots = if function_exported?(module, :__slots__, 0), do: module.slots(), else: []
+      data = if function_exported?(module, :__data__, 0), do: module.__data__(), else: []
+      props = if function_exported?(module, :__props__, 0), do: module.__props__(), else: []
+      slots = if function_exported?(module, :__slots__, 0), do: module.__slots__(), else: []
 
       Enum.map(data ++ props ++ slots, fn %{name: name} -> name end)
     end

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -66,8 +66,8 @@ defmodule Surface.AST.Meta do
       * `:line_offset` - the line offset from the caller's line to the start of this source
       * `:caller` - a Macro.Env struct representing the caller
   """
-  @derive {Inspect, only: [:line, :module, :node_alias, :file]}
-  defstruct [:line, :module, :node_alias, :line_offset, :file, :caller]
+  @derive {Inspect, only: [:line, :module, :node_alias, :file, :checks]}
+  defstruct [:line, :module, :node_alias, :line_offset, :file, :caller, :checks]
 
   @type t :: %__MODULE__{
           line: non_neg_integer(),
@@ -75,7 +75,8 @@ defmodule Surface.AST.Meta do
           module: atom(),
           node_alias: binary() | nil,
           caller: Macro.Env.t(),
-          file: binary()
+          file: binary(),
+          checks: Keyword.t(boolean())
         }
 
   def quoted_caller_cid(meta) do

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -84,7 +84,9 @@ defmodule Surface.Compiler do
   string is also the first line of the file, then this should be 1. If this is being called within a macro (say to process a heredoc
   passed to ~H), this should be __CALLER__.line + 1.
   """
-  @spec compile(binary, non_neg_integer(), Macro.Env.t(), binary(), Keyword.t()) :: [Surface.AST.t()]
+  @spec compile(binary, non_neg_integer(), Macro.Env.t(), binary(), Keyword.t()) :: [
+          Surface.AST.t()
+        ]
   def compile(string, line_offset, caller, file \\ "nofile", opts \\ []) do
     compile_meta = %CompileMeta{
       line_offset: line_offset,

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -201,7 +201,7 @@ defmodule Surface.Compiler do
     expr = Helpers.interpolation_to_quoted!(text, meta)
 
     if compile_meta.checks[:no_undefined_assigns] do
-      Helpers.validate_assign_usage(expr, compile_meta.caller)
+      Helpers.validate_no_undefined_assigns(expr, compile_meta.caller)
     end
 
     {:ok,

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -200,9 +200,7 @@ defmodule Surface.Compiler do
 
     expr = Helpers.interpolation_to_quoted!(text, meta)
 
-    if compile_meta.checks[:no_undefined_assigns] do
-      Helpers.validate_no_undefined_assigns(expr, compile_meta.caller)
-    end
+    Helpers.perform_assigns_checks(expr, compile_meta)
 
     {:ok,
      %AST.Interpolation{

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -27,17 +27,18 @@ defmodule Surface.Compiler.Helpers do
   end
 
   def perform_assigns_checks(expr, meta) do
+    used_assigns = used_assigns(expr)
+
     if meta.checks[:no_unused_assigns] do
-      validate_no_unused_assigns(expr, meta.caller)
+      validate_no_unused_assigns(used_assigns, meta.caller)
     end
 
     if meta.checks[:no_undefined_assigns] do
-      validate_no_undefined_assigns(expr, meta.caller)
+      validate_no_undefined_assigns(used_assigns, meta.caller)
     end
   end
 
-  def validate_no_undefined_assigns(expr, caller) do
-    used_assigns = used_assigns(expr)
+  def validate_no_undefined_assigns(used_assigns, caller) do
     defined_assigns = Keyword.keys(Surface.API.get_assigns(caller.module))
 
     undefined_assigns = Keyword.drop(used_assigns, @builtin_assigns ++ defined_assigns)
@@ -67,16 +68,13 @@ defmodule Surface.Compiler.Helpers do
     end
   end
 
-  def validate_no_unused_assigns(expr, caller) do
-    used_assigns = used_assigns(expr)
+  def validate_no_unused_assigns(used_assigns, caller) do
     defined_assigns = Surface.API.get_assigns(caller.module)
 
     unused_assigns = Keyword.drop(defined_assigns, [:id, :session] ++ Keyword.keys(used_assigns))
 
     for {assign, line} <- unused_assigns do
-      message = """
-      unused assign `@#{to_string(assign)}`.
-      """
+      message = "unused assign `@#{to_string(assign)}`."
 
       IOHelper.warn(message, caller, fn _ -> line end)
     end

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -3,7 +3,7 @@ defmodule Surface.Compiler.Helpers do
   alias Surface.Compiler.CompileMeta
   alias Surface.IOHelper
 
-  @surface_assigns [:__context__, :inner_content, :__surface__]
+  @builtin_assigns [:flash, :live_action, :live_module, :socket, :inner_block, :__context__, :__surface__]
 
   def interpolation_to_quoted!(text, meta) do
     case Code.string_to_quoted(text, file: meta.file, line: meta.line) do
@@ -22,7 +22,7 @@ defmodule Surface.Compiler.Helpers do
     used_assigns = used_assigns(expr)
     defined_assigns = Surface.API.get_assigns(caller.module)
 
-    undefined_assigns = Keyword.drop(used_assigns, @surface_assigns ++ defined_assigns)
+    undefined_assigns = Keyword.drop(used_assigns, @builtin_assigns ++ defined_assigns)
 
     available_assigns =
       Enum.map_join(defined_assigns, ", ", fn name -> "@" <> to_string(name) end)

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -38,8 +38,9 @@ defmodule Surface.Compiler.Helpers do
 
       #{assign_message}
 
-      Hint: You can define a new prop using the `prop` macro: \
-      `prop #{assign}, :any`\
+      Hint: You can define assigns using any of the available macros (`prop`, `data` and `slot`).
+
+      For instance: `prop #{assign}, :any`
       """
 
       assign_line = assign_meta[:line] || caller.line

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -29,10 +29,6 @@ defmodule Surface.Compiler.Helpers do
   def perform_assigns_checks(expr, meta) do
     used_assigns = used_assigns(expr)
 
-    if meta.checks[:no_unused_assigns] do
-      validate_no_unused_assigns(used_assigns, meta.caller)
-    end
-
     if meta.checks[:no_undefined_assigns] do
       validate_no_undefined_assigns(used_assigns, meta.caller)
     end
@@ -65,18 +61,6 @@ defmodule Surface.Compiler.Helpers do
       assign_line = assign_meta[:line] || caller.line
 
       IOHelper.warn(message, caller, fn _ -> assign_line end)
-    end
-  end
-
-  def validate_no_unused_assigns(used_assigns, caller) do
-    defined_assigns = Surface.API.get_assigns(caller.module)
-
-    unused_assigns = Keyword.drop(defined_assigns, [:id, :session] ++ Keyword.keys(used_assigns))
-
-    for {assign, line} <- unused_assigns do
-      message = "unused assign `@#{to_string(assign)}`."
-
-      IOHelper.warn(message, caller, fn _ -> line end)
     end
   end
 

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -3,7 +3,15 @@ defmodule Surface.Compiler.Helpers do
   alias Surface.Compiler.CompileMeta
   alias Surface.IOHelper
 
-  @builtin_assigns [:flash, :live_action, :live_module, :socket, :inner_block, :__context__, :__surface__]
+  @builtin_assigns [
+    :flash,
+    :live_action,
+    :live_module,
+    :socket,
+    :inner_block,
+    :__context__,
+    :__surface__
+  ]
 
   def interpolation_to_quoted!(text, meta) do
     case Code.string_to_quoted(text, file: meta.file, line: meta.line) do
@@ -51,10 +59,11 @@ defmodule Surface.Compiler.Helpers do
 
   @spec used_assigns(Macro.t()) :: list(atom())
   def used_assigns(expr) do
-    {_expr, assigns} = Macro.prewalk(expr, [], fn
-      {:@, _meta, [{assign, meta, _}]} = expr, assigns -> {expr, [{assign, meta} | assigns]}
+    {_expr, assigns} =
+      Macro.prewalk(expr, [], fn
+        {:@, _meta, [{assign, meta, _}]} = expr, assigns -> {expr, [{assign, meta} | assigns]}
         expr, assigns -> {expr, assigns}
-    end)
+      end)
 
     assigns
   end

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -50,16 +50,14 @@ defmodule Surface.Compiler.Helpers do
   end
 
   @spec used_assigns(Macro.t()) :: list(atom())
-  def used_assigns(atom) when is_atom(atom), do: []
-  def used_assigns(number) when is_number(number), do: []
-  def used_assigns(binary) when is_binary(binary), do: []
-  def used_assigns({first, second}), do: used_assigns(first) ++ used_assigns(second)
-  def used_assigns(list) when is_list(list), do: Enum.flat_map(list, &used_assigns/1)
+  def used_assigns(expr) do
+    {_expr, assigns} = Macro.prewalk(expr, [], fn
+      {:@, _meta, [{assign, meta, _}]} = expr, assigns -> {expr, [{assign, meta} | assigns]}
+        expr, assigns -> {expr, assigns}
+    end)
 
-  def used_assigns({:@, _at_meta, [{assign, meta, args}]}),
-    do: [{assign, meta} | used_assigns(args)]
-
-  def used_assigns({first, _meta, second}), do: used_assigns(first) ++ used_assigns(second)
+    assigns
+  end
 
   def to_meta(%{line: line} = tree_meta, %CompileMeta{
         line_offset: offset,

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -26,7 +26,7 @@ defmodule Surface.Compiler.Helpers do
     end
   end
 
-  def validate_assign_usage(expr, caller) do
+  def validate_no_undefined_assigns(expr, caller) do
     used_assigns = used_assigns(expr)
     defined_assigns = Surface.API.get_assigns(caller.module)
 

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -121,7 +121,7 @@ defmodule Surface.TypeHandler do
     with {:ok, ast} <- normalize_expr(value, line: meta.line, file: meta.file),
          _ <-
            !meta.checks[:no_undefined_assigns] ||
-             Surface.Compiler.Helpers.validate_assign_usage(ast, meta.caller),
+             Surface.Compiler.Helpers.validate_no_undefined_assigns(ast, meta.caller),
          {clauses, opts} <- split_clauses_and_options(ast),
          true <- clauses != [] or opts != [],
          handler <- handler(type),

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -119,9 +119,7 @@ defmodule Surface.TypeHandler do
     original = original || value
 
     with {:ok, ast} <- normalize_expr(value, line: meta.line, file: meta.file),
-         _ <-
-           !meta.checks[:no_undefined_assigns] ||
-             Surface.Compiler.Helpers.validate_no_undefined_assigns(ast, meta.caller),
+         _ <- Surface.Compiler.Helpers.perform_assigns_checks(ast, meta),
          {clauses, opts} <- split_clauses_and_options(ast),
          true <- clauses != [] or opts != [],
          handler <- handler(type),

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -119,6 +119,7 @@ defmodule Surface.TypeHandler do
     original = original || value
 
     with {:ok, ast} <- normalize_expr(value, line: meta.line, file: meta.file),
+          _ <- !meta.checks[:no_undefined_assigns] || Surface.Compiler.Helpers.validate_assign_usage(ast, meta.caller),
          {clauses, opts} <- split_clauses_and_options(ast),
          true <- clauses != [] or opts != [],
          handler <- handler(type),

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -119,7 +119,9 @@ defmodule Surface.TypeHandler do
     original = original || value
 
     with {:ok, ast} <- normalize_expr(value, line: meta.line, file: meta.file),
-          _ <- !meta.checks[:no_undefined_assigns] || Surface.Compiler.Helpers.validate_assign_usage(ast, meta.caller),
+         _ <-
+           !meta.checks[:no_undefined_assigns] ||
+             Surface.Compiler.Helpers.validate_assign_usage(ast, meta.caller),
          {clauses, opts} <- split_clauses_and_options(ast),
          true <- clauses != [] or opts != [],
          handler <- handler(type),

--- a/test/compiler/helpers_test.exs
+++ b/test/compiler/helpers_test.exs
@@ -13,7 +13,7 @@ defmodule Surface.Compiler.HelpersTest do
         |> Helpers.used_assigns()
         |> Keyword.keys()
 
-      assert [:something, :something_else, :list] = assigns
+      assert [:list, :something_else, :something] = assigns
     end
 
     test "returns empty list when no assigns referenced via @assign_name" do

--- a/test/compiler/helpers_test.exs
+++ b/test/compiler/helpers_test.exs
@@ -1,0 +1,39 @@
+defmodule Surface.Compiler.HelpersTest do
+  use ExUnit.Case
+
+  alias Surface.Compiler.Helpers
+
+  describe "used_assigns" do
+    test "detects all assigns referenced via @assign_name" do
+      assigns = quote do
+        value = @something + @something_else
+        Enum.map(@list, fn value -> value end)
+      end
+      |> Helpers.used_assigns()
+      |> Keyword.keys()
+
+      assert [:something, :something_else, :list] = assigns
+    end
+
+    test "returns empty list when no assigns referenced via @assign_name" do
+      assigns = quote do
+        the_value + 1
+      end
+      |> Helpers.used_assigns()
+      |> Keyword.keys()
+
+      assert [] = assigns
+    end
+
+    test "returns empty list when assigns only referenced by dot-notation" do
+      assigns = quote do
+        value = assigns.something + assigns.something_else
+        Enum.map(assigns.list, fn value -> value end)
+      end
+      |> Helpers.used_assigns()
+      |> Keyword.keys()
+
+      assert [] = assigns
+    end
+  end
+end

--- a/test/compiler/helpers_test.exs
+++ b/test/compiler/helpers_test.exs
@@ -5,33 +5,36 @@ defmodule Surface.Compiler.HelpersTest do
 
   describe "used_assigns" do
     test "detects all assigns referenced via @assign_name" do
-      assigns = quote do
-        value = @something + @something_else
-        Enum.map(@list, fn value -> value end)
-      end
-      |> Helpers.used_assigns()
-      |> Keyword.keys()
+      assigns =
+        quote do
+          value = @something + @something_else
+          Enum.map(@list, fn value -> value end)
+        end
+        |> Helpers.used_assigns()
+        |> Keyword.keys()
 
       assert [:something, :something_else, :list] = assigns
     end
 
     test "returns empty list when no assigns referenced via @assign_name" do
-      assigns = quote do
-        the_value + 1
-      end
-      |> Helpers.used_assigns()
-      |> Keyword.keys()
+      assigns =
+        quote do
+          the_value + 1
+        end
+        |> Helpers.used_assigns()
+        |> Keyword.keys()
 
       assert [] = assigns
     end
 
     test "returns empty list when assigns only referenced by dot-notation" do
-      assigns = quote do
-        value = assigns.something + assigns.something_else
-        Enum.map(assigns.list, fn value -> value end)
-      end
-      |> Helpers.used_assigns()
-      |> Keyword.keys()
+      assigns =
+        quote do
+          value = assigns.something + assigns.something_else
+          Enum.map(assigns.list, fn value -> value end)
+        end
+        |> Helpers.used_assigns()
+        |> Keyword.keys()
 
       assert [] = assigns
     end

--- a/test/components/form_test.exs
+++ b/test/components/form_test.exs
@@ -9,6 +9,8 @@ defmodule Surface.Components.FormTest do
   defmodule ViewWithForm do
     use Surface.LiveView
 
+    data changeset, :any
+
     def render(assigns) do
       ~H"""
       <Form for={{ @changeset }} action="#" opts={{ csrf_token: "test", as: :user }}>

--- a/test/context_change_tracking_test.exs
+++ b/test/context_change_tracking_test.exs
@@ -41,6 +41,7 @@ defmodule Surface.ContextChangeTrackingTest do
     alias Surface.CheckUpdated
 
     data count, :integer, default: 0
+    data test_pid, :integer
 
     def mount(_params, %{"test_pid" => test_pid}, socket) do
       {:ok, assign(socket, test_pid: test_pid)}

--- a/test/live_component_change_tracking_test.exs
+++ b/test/live_component_change_tracking_test.exs
@@ -12,6 +12,7 @@ defmodule LiveComponentChangeTrackingTest do
     use Surface.LiveView
 
     data count, :integer, default: 0
+    data test_pid, :integer
 
     def mount(_params, %{"test_pid" => test_pid}, socket) do
       {:ok, assign(socket, test_pid: test_pid)}
@@ -34,6 +35,7 @@ defmodule LiveComponentChangeTrackingTest do
 
     data count, :integer, default: 0
     data passing_count, :integer, default: 0
+    data test_pid, :integer
 
     def mount(_params, %{"test_pid" => test_pid}, socket) do
       {:ok, assign(socket, test_pid: test_pid)}

--- a/test/live_component_test.exs
+++ b/test/live_component_test.exs
@@ -23,6 +23,7 @@ defmodule LiveComponentTest do
     use Surface.LiveComponent
 
     data label, :string, default: "Initial stateful"
+    data assigned_in_update, :any
 
     def update(_assigns, socket) do
       {:ok, assign(socket, assigned_in_update: "Assinged in update/2")}

--- a/test/slot_change_tracking_test.exs
+++ b/test/slot_change_tracking_test.exs
@@ -23,6 +23,7 @@ defmodule Surface.SlotChangeTrackingTest do
     alias Surface.CheckUpdated
 
     data count, :integer, default: 0
+    data test_pid, :integer
 
     def mount(_params, %{"test_pid" => test_pid}, socket) do
       {:ok, assign(socket, test_pid: test_pid)}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -65,6 +65,7 @@ defmodule ComponentTestHelper do
     view_code = """
     defmodule TestLiveView_#{id} do; \
       use Surface.LiveView; \
+      #{ for {name, _} <- assigns, into: "", do: "prop " <> to_string(name) <> ", :any; "} \
       def render(assigns) do; \
         assigns = Map.merge(assigns, #{inspect(assigns)}); \
         ~H(#{code}); \

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -65,7 +65,7 @@ defmodule ComponentTestHelper do
     view_code = """
     defmodule TestLiveView_#{id} do; \
       use Surface.LiveView; \
-      #{ for {name, _} <- assigns, into: "", do: "prop " <> to_string(name) <> ", :any; "} \
+      #{for {name, _} <- assigns, into: "", do: "prop " <> to_string(name) <> ", :any; "} \
       def render(assigns) do; \
         assigns = Map.merge(assigns, #{inspect(assigns)}); \
         ~H(#{code}); \


### PR DESCRIPTION
This adds compile time warnings if any undefined assigns are used in a Surface.LiveView, Surface.LiveComponent, or Surface.Component. The instigation for this was the switch back to variables for all of the context vars and slot props - I wanted an easier way to figure out if I had missed any assign -> var

It's a warn and not an error because an undefined assign doesn't necessarily mean it wont be there at runtime