### PR TITLE
Remove <div> wrapper from <Field>

### DIFF
--- a/lib/surface/components/form/field.ex
+++ b/lib/surface/components/form/field.ex
@@ -12,9 +12,6 @@ defmodule Surface.Components.Form.Field do
   @doc "The field name"
   prop name, :atom, required: true
 
-  @doc "The CSS class for the generated `<div>` element"
-  prop class, :css_class
-
   @doc """
   The content for the field
   """
@@ -22,15 +19,9 @@ defmodule Surface.Components.Form.Field do
 
   def render(assigns) do
     ~H"""
-    <div class={{ class_value(@class) }}>
-      <Context put={{ __MODULE__, field: @name }}>
-        <slot/>
-      </Context>
-    </div>
+    <Context put={{ __MODULE__, field: @name }}>
+      <slot/>
+    </Context>
     """
-  end
-
-  defp class_value(class) do
-    class || get_config(:default_class) || ""
   end
 end

--- a/test/components/field_test.exs
+++ b/test/components/field_test.exs
@@ -5,34 +5,6 @@ defmodule Surface.Components.FieldTest do
 
   import ComponentTestHelper
 
-  test "creates a wrapping <div> for the field's content" do
-    code = """
-    <Field name="name">
-      Hi
-    </Field>
-    """
-
-    assert render_live(code) =~ """
-           <div>
-             Hi
-           </div>
-           """
-  end
-
-  test "property class" do
-    code = """
-    <Field name="name" class={{ :field }}>
-      Hi
-    </Field>
-    """
-
-    assert render_live(code) =~ """
-           <div class="field">
-             Hi
-           </div>
-           """
-  end
-
   test "sets the provided field into the context" do
     code = """
     <Field name="my_field">
@@ -41,22 +13,5 @@ defmodule Surface.Components.FieldTest do
     """
 
     assert render_live(code) =~ ~S(name="my_form[my_field]")
-  end
-end
-
-defmodule Surface.Components.Form.FieldConfigTest do
-  use ExUnit.Case
-
-  alias Surface.Components.Form.Field, warn: false
-  import ComponentTestHelper
-
-  test ":default_class config" do
-    using_config Field, default_class: "default_class" do
-      code = """
-      <Field name="name">Hi</Field>
-      """
-
-      assert render_live(code) =~ ~r/class="default_class"/
-    end
   end
 end


### PR DESCRIPTION
I'd like to propose that the `<div>` wrapper of the `<Field>` component be removed.

I ran into a use case using a `:first-child` CSS selector where this extra wrapper broke the visual layout I was going for.

Perhaps there's a reason I'm not seeing that would make this `<div>` desired or necessary? If not, I think this would make `<Field>` more flexible. Thanks for considering!