### PR TITLE
allow double braces within interpolation

### DIFF
--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -136,11 +136,51 @@ defmodule Surface.Compiler.Parser do
   end
 
   ## Regular node
+  defparsecp(
+    :tuple,
+    string("{")
+    |> choice([
+      parsec(:tuple),
+      repeat(utf8_char(not: ?}))
+    ])
+    |> string("}")
+  )
+
+  defparsecp(
+    :binary,
+    string("\"")
+    |> repeat(
+      choice([
+        string("\\\""),
+        utf8_char(not: ?")
+      ])
+    )
+    |> string("\"")
+  )
+
+  defparsecp(
+    :charlist,
+    string("\'")
+    |> repeat(
+      choice([
+        string("\\'"),
+        utf8_char(not: ?')
+      ])
+    )
+    |> string("\'")
+  )
 
   interpolation =
     ignore(string("{{"))
     |> line()
-    |> repeat(lookahead_not(string("}}")) |> utf8_char([]))
+    |> repeat(
+      choice([
+        parsec(:tuple),
+        parsec(:binary),
+        parsec(:charlist),
+        lookahead_not(string("}}")) |> utf8_char([])
+      ])
+    )
     |> optional(string("}}"))
     |> post_traverse(:interpolation)
 

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -137,16 +137,6 @@ defmodule Surface.Compiler.Parser do
 
   ## Regular node
   defparsecp(
-    :tuple,
-    string("{")
-    |> choice([
-      parsec(:tuple),
-      repeat(utf8_char(not: ?}))
-    ])
-    |> string("}")
-  )
-
-  defparsecp(
     :binary,
     string("\"")
     |> repeat(
@@ -168,6 +158,18 @@ defmodule Surface.Compiler.Parser do
       ])
     )
     |> string("\'")
+  )
+
+  defparsecp(
+    :tuple,
+    string("{")
+    |> choice([
+      parsec(:tuple),
+      parsec(:binary),
+      parsec(:charlist),
+      repeat(utf8_char(not: ?}))
+    ])
+    |> string("}")
   )
 
   interpolation =

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -193,6 +193,16 @@ defmodule Surface.Compiler.ParserTest do
                {:ok, [{:interpolation, "baz", %{line: 1}}]}
     end
 
+    test "with double curlies embedded" do
+      assert parse("{{ {{1, 3}, {4, 5}} }}") ==
+               {:ok, [{:interpolation, " {{1, 3}, {4, 5}} ", %{line: 1}}]}
+    end
+
+    test "with deeply nested curlies" do
+      assert parse("{{ {{{{{{{{{{}}}}}}}}}} }}") ==
+               {:ok, [{:interpolation, " {{{{{{{{{{}}}}}}}}}} ", %{line: 1}}]}
+    end
+
     test "without root node but with text" do
       assert parse("foo {{baz}} bar") ==
                {:ok, ["foo ", {:interpolation, "baz", %{line: 1}}, " bar"]}
@@ -224,6 +234,36 @@ defmodule Surface.Compiler.ParserTest do
                   {"foo", [], ["bar", {:interpolation, " 'a}b' ", %{line: 1}}, "bat"],
                    %{line: 1, space: ""}}
                 ]}
+    end
+
+    test "double closing curly brace inside charlist" do
+      assert parse("{{ 'a}}b' }}") ==
+               {:ok, [{:interpolation, " 'a}}b' ", %{line: 1}}]}
+    end
+
+    test "double closing curly brace inside binary" do
+      assert parse("{{ \"a}}b\" }}") ==
+               {:ok, [{:interpolation, " \"a}}b\" ", %{line: 1}}]}
+    end
+
+    test "single-opening curly bracket inside single quotes" do
+      assert parse("{{ 'a{b' }}") ==
+               {:ok, [{:interpolation, " 'a{b' ", %{line: 1}}]}
+    end
+
+    test "single-opening curly bracket inside double quotes" do
+      assert parse("{{ \"a{b\" }}") ==
+               {:ok, [{:interpolation, " \"a{b\" ", %{line: 1}}]}
+    end
+
+    test "containing a charlist with escaped single quote" do
+      assert parse("{{ 'a\\'b' }}") ==
+               {:ok, [{:interpolation, " 'a\\'b' ", %{line: 1}}]}
+    end
+
+    test "containing a binary with escaped double quote" do
+      assert parse("{{ \"a\\\"b\" }}") ==
+               {:ok, [{:interpolation, " \"a\\\"b\" ", %{line: 1}}]}
     end
   end
 
@@ -334,6 +374,11 @@ defmodule Surface.Compiler.ParserTest do
 
     test "non-closing interpolation" do
       assert parse("<foo>{{bar</foo>") ==
+               {:error, "expected closing for interpolation", 1}
+    end
+
+    test "non-matched curlies inside interpolation" do
+      assert parse("<foo>{{bar { }}</foo>") ==
                {:error, "expected closing for interpolation", 1}
     end
   end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -615,5 +615,19 @@ defmodule Surface.Compiler.ParserTest do
 
       assert parse(code) == {:ok, [{"foo", attributes, [], %{line: 1, space: ""}}, "\n"]}
     end
+
+    test "interpolation with nested curlies" do
+      code = """
+      <foo prop={{ {{}} }}/>
+      """
+
+      attr_value = {:attribute_expr, " {{}} ", %{line: 1}}
+
+      attributes = [
+        {"prop", attr_value, %{line: 1, spaces: [" ", "", ""]}}
+      ]
+
+      assert parse(code) == {:ok, [{"foo", attributes, [], %{line: 1, space: ""}}, "\n"]}
+    end
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -205,12 +205,12 @@ defmodule Surface.Compiler.ParserTest do
 
     test "matched curlies for a map expression" do
       assert parse("{{ %{a: %{b: 1}} }}") ==
-        {:ok, [{:interpolation, " %{a: %{b: 1}} ", %{line: 1}}]}
+               {:ok, [{:interpolation, " %{a: %{b: 1}} ", %{line: 1}}]}
     end
 
     test "tuple without spaces between enclosing curlies" do
       assert parse("{{{:a, :b}}}") ==
-        {:ok, [{:interpolation, "{:a, :b}", %{line: 1}}]}
+               {:ok, [{:interpolation, "{:a, :b}", %{line: 1}}]}
     end
 
     test "without root node but with text" do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -203,6 +203,16 @@ defmodule Surface.Compiler.ParserTest do
                {:ok, [{:interpolation, " {{{{{{{{{{}}}}}}}}}} ", %{line: 1}}]}
     end
 
+    test "matched curlies for a map expression" do
+      assert parse("{{ %{a: %{b: 1}} }}") ==
+        {:ok, [{:interpolation, " %{a: %{b: 1}} ", %{line: 1}}]}
+    end
+
+    test "tuple without spaces between enclosing curlies" do
+      assert parse("{{{:a, :b}}}") ==
+        {:ok, [{:interpolation, "{:a, :b}", %{line: 1}}]}
+    end
+
     test "without root node but with text" do
       assert parse("foo {{baz}} bar") ==
                {:ok, ["foo ", {:interpolation, "baz", %{line: 1}}, " bar"]}

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -236,9 +236,19 @@ defmodule Surface.Compiler.ParserTest do
                 ]}
     end
 
-    test "double closing curly brace inside charlist" do
+    test "charlist with closing curly in tuple" do
       assert parse("{{ 'a}}b' }}") ==
                {:ok, [{:interpolation, " 'a}}b' ", %{line: 1}}]}
+    end
+
+    test "binary with closing curly in tuple" do
+      assert parse("{{ {{'a}}b'}} }}") ==
+               {:ok, [{:interpolation, " {{'a}}b'}} ", %{line: 1}}]}
+    end
+
+    test "double closing curly brace inside charlist" do
+      assert parse("{{ {{\"a}}b\"}} }}") ==
+               {:ok, [{:interpolation, " {{\"a}}b\"}} ", %{line: 1}}]}
     end
 
     test "double closing curly brace inside binary" do


### PR DESCRIPTION
this updates the parser to allow curly braces within interpolation
as long as all of the braces are matched, and ignore any curly braces
inside binaries and charlists.

Fixes #156