### PR TITLE
Add <FieldContext>

### DIFF
--- a/lib/surface/components/form/field_context.ex
+++ b/lib/surface/components/form/field_context.ex
@@ -1,0 +1,29 @@
+defmodule Surface.Components.Form.FieldContext do
+  @moduledoc """
+  Defines a context for a form field but without the `<div>` wrapper in `Field`.
+
+  Like the `Field` component, sets the provided field name into the context
+  so child components like input fields and labels can retrieve it and use it as
+  the default field.
+  """
+
+  use Surface.Component
+
+  alias Surface.Components.Form.Field
+
+  @doc "The field name"
+  prop name, :atom, required: true
+
+  @doc """
+  The content for the field
+  """
+  slot default, required: true
+
+  def render(assigns) do
+    ~H"""
+    <Context put={{ Field, field: @name }}>
+      <slot/>
+    </Context>
+    """
+  end
+end

--- a/test/components/field_context_test.exs
+++ b/test/components/field_context_test.exs
@@ -1,0 +1,17 @@
+defmodule Surface.Components.FieldContextTest do
+  use ExUnit.Case, async: true
+
+  alias Surface.Components.Form.{FieldContext, TextInput}, warn: false
+
+  import ComponentTestHelper
+
+  test "sets the provided field into the context" do
+    code = """
+    <FieldContext name="my_field">
+      <TextInput form="my_form"/>
+    </FieldContext>
+    """
+
+    assert render_live(code) =~ ~S(name="my_form[my_field]")
+  end
+end


### PR DESCRIPTION
This adds a way to put a field name into context like `Surface.Components.Form.Field` but without wrapping the contents in an extra `<div>`:

```html
<FieldContext name="last_name">
  <TextInput />
</FieldContext>
```

yields:

```html
<input ... />
```

instead of:

```html
<div>
  <input ... />
</div>
```