### PR TITLE
Fix modifiers on components

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -597,7 +597,7 @@ defmodule Surface.Compiler do
     {name, modifiers} =
       case String.split(attr_name, ".") do
         [name] ->
-          {name, []}
+          {name, Map.get(meta, :modifiers, [])}
 
         [name | modifiers] ->
           {name, modifiers}

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -190,11 +190,14 @@ defmodule Surface.DirectivesTest do
     test "modifiers on components" do
       assigns = %{items: [1, 2]}
 
-      code = """
-      <Div :for.with_index={{ {iii, index} <- @items }}>
-        Item: {{ iii }}, Index: {{ index }}
-      </Div>
-      """
+      code =
+        quote do
+          ~H"""
+          <Div :for.with_index={{ {iii, index} <- @items }}>
+            Item: {{ iii }}, Index: {{ index }}
+          </Div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -14,6 +14,20 @@ defmodule Surface.DirectivesTest do
     end
   end
 
+  defmodule DivWithIndex do
+    use Surface.Component
+
+    prop items, :list
+
+    def render(assigns) do
+      ~H"""
+      <Div :for.with_index={{ {iii, index} <- @items }}>
+        Item: {{ iii }}, Index: {{ index }}
+      </Div>
+      """
+    end
+  end
+
   defmodule DivWithProps do
     use Surface.Component
 
@@ -183,6 +197,20 @@ defmodule Surface.DirectivesTest do
                i: 0, j: 0
              </div><div>
                i: 1, j: 1
+             </div>
+             """
+    end
+
+    test "modifiers on components" do
+      code = """
+      <DivWithIndex items={{ [1, 2] }}/>
+      """
+
+      assert render_live(code) =~ """
+             <div>
+               Item: 1, Index: 0
+             </div><div>
+               Item: 2, Index: 1
              </div>
              """
     end

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -14,20 +14,6 @@ defmodule Surface.DirectivesTest do
     end
   end
 
-  defmodule DivWithIndex do
-    use Surface.Component
-
-    prop items, :list
-
-    def render(assigns) do
-      ~H"""
-      <Div :for.with_index={{ {iii, index} <- @items }}>
-        Item: {{ iii }}, Index: {{ index }}
-      </Div>
-      """
-    end
-  end
-
   defmodule DivWithProps do
     use Surface.Component
 
@@ -202,11 +188,15 @@ defmodule Surface.DirectivesTest do
     end
 
     test "modifiers on components" do
+      assigns = %{items: [1, 2]}
+
       code = """
-      <DivWithIndex items={{ [1, 2] }}/>
+      <Div :for.with_index={{ {iii, index} <- @items }}>
+        Item: {{ iii }}, Index: {{ index }}
+      </Div>
       """
 
-      assert render_live(code) =~ """
+      assert render_live(code, assigns) =~ """
              <div>
                Item: 1, Index: 0
              </div><div>


### PR DESCRIPTION
Fixes #175.

@lnr0626 the problem was that `extract_modifiers` didn't expect to be called twice for the same attribute. This happens because `collect_directives` is called twice for components. Here:
https://github.com/msaraiva/surface/blob/83919af9c1d479bb98f0788aed0abf4091826649/lib/surface/compiler.ex#L328 

and here:
https://github.com/msaraiva/surface/blob/83919af9c1d479bb98f0788aed0abf4091826649/lib/surface/compiler.ex#L521.

Not sure if this could bring any other trouble in the future.