### PR TITLE
Replace render_live

### DIFF
--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -150,9 +150,12 @@ defmodule Surface.ComponentTest do
 
   describe "Without LiveView" do
     test "render stateless component" do
-      code = """
-      <Stateless label="My label" class="myclass"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <Stateless label="My label" class="myclass"/>
+          """
+        end
 
       assert render_live(code) =~ """
              <div class="myclass"><span>My label</span></div>
@@ -160,11 +163,14 @@ defmodule Surface.ComponentTest do
     end
 
     test "render nested component's content" do
-      code = """
-      <Outer>
-        <Inner/>
-      </Outer>
-      """
+      code =
+        quote do
+          ~H"""
+          <Outer>
+            <Inner/>
+          </Outer>
+          """
+        end
 
       assert render_live(code) =~ """
              <div><span>Inner</span></div>
@@ -172,11 +178,14 @@ defmodule Surface.ComponentTest do
     end
 
     test "render content with slot props" do
-      code = """
-      <OuterWithSlotProps :let={{ info: my_info }}>
-        {{ my_info }}
-      </OuterWithSlotProps>
-      """
+      code =
+        quote do
+          ~H"""
+          <OuterWithSlotProps :let={{ info: my_info }}>
+            {{ my_info }}
+          </OuterWithSlotProps>
+          """
+        end
 
       assert render_live(code) =~ """
              <div>
@@ -196,11 +205,14 @@ defmodule Surface.ComponentTest do
     test "render error message if module is not a component" do
       import ExUnit.CaptureIO
 
-      code = """
-      <div>
-        <Enum/>
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <div>
+            <Enum/>
+          </div>
+          """
+        end
 
       output =
         capture_io(:standard_error, fn ->

--- a/test/components/field_context_test.exs
+++ b/test/components/field_context_test.exs
@@ -6,11 +6,14 @@ defmodule Surface.Components.FieldContextTest do
   import ComponentTestHelper
 
   test "sets the provided field into the context" do
-    code = """
-    <FieldContext name="my_field">
-      <TextInput form="my_form"/>
-    </FieldContext>
-    """
+    code =
+      quote do
+        ~H"""
+        <FieldContext name="my_field">
+          <TextInput form="my_form"/>
+        </FieldContext>
+        """
+      end
 
     assert render_live(code) =~ ~S(name="my_form[my_field]")
   end

--- a/test/components/field_test.exs
+++ b/test/components/field_test.exs
@@ -6,11 +6,14 @@ defmodule Surface.Components.FieldTest do
   import ComponentTestHelper
 
   test "creates a wrapping <div> for the field's content" do
-    code = """
-    <Field name="name">
-      Hi
-    </Field>
-    """
+    code =
+      quote do
+        ~H"""
+        <Field name="name">
+          Hi
+        </Field>
+        """
+      end
 
     assert render_live(code) =~ """
            <div>
@@ -20,11 +23,14 @@ defmodule Surface.Components.FieldTest do
   end
 
   test "property class" do
-    code = """
-    <Field name="name" class={{ :field }}>
-      Hi
-    </Field>
-    """
+    code =
+      quote do
+        ~H"""
+        <Field name="name" class={{ :field }}>
+          Hi
+        </Field>
+        """
+      end
 
     assert render_live(code) =~ """
            <div class="field">
@@ -34,11 +40,14 @@ defmodule Surface.Components.FieldTest do
   end
 
   test "sets the provided field into the context" do
-    code = """
-    <Field name="my_field">
-      <TextInput form="my_form"/>
-    </Field>
-    """
+    code =
+      quote do
+        ~H"""
+        <Field name="my_field">
+          <TextInput form="my_form"/>
+        </Field>
+        """
+      end
 
     assert render_live(code) =~ ~S(name="my_form[my_field]")
   end
@@ -52,9 +61,12 @@ defmodule Surface.Components.Form.FieldConfigTest do
 
   test ":default_class config" do
     using_config Field, default_class: "default_class" do
-      code = """
-      <Field name="name">Hi</Field>
-      """
+      code =
+        quote do
+          ~H"""
+          <Field name="name">Hi</Field>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/checkbox_test.exs
+++ b/test/components/form/checkbox_test.exs
@@ -7,9 +7,12 @@ defmodule Surface.Components.Form.CheckboxTest do
   import ComponentTestHelper
 
   test "checkbox" do
-    code = """
-    <Checkbox form="user" field="admin" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_admin" name="user[admin]" type="checkbox" value="true"/>
@@ -17,11 +20,14 @@ defmodule Surface.Components.Form.CheckboxTest do
   end
 
   test "with form context" do
-    code = """
-    <Form for={{ :user }} opts={{ csrf_token: "test" }}>
-      <Checkbox field={{ :admin }} />
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :user }} opts={{ csrf_token: "test" }}>
+          <Checkbox field={{ :admin }} />
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post">\
@@ -33,25 +39,34 @@ defmodule Surface.Components.Form.CheckboxTest do
   end
 
   test "setting the class" do
-    code = """
-    <Checkbox form="user" field="admin" class="checkbox" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" class="checkbox" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="checkbox"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <Checkbox form="user" field="admin" class="checkbox primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" class="checkbox primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="checkbox primary"/
   end
 
   test "passing other options" do
-    code = """
-    <Checkbox form="user" field="admin" opts={{ checked_value: "admin" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" opts={{ checked_value: "admin" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_admin" name="user[admin]" type="checkbox" value="admin"/>
@@ -59,9 +74,12 @@ defmodule Surface.Components.Form.CheckboxTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <Checkbox form="user" field="admin" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_admin" name="user[admin]" phx-blur="my_blur" type="checkbox" value="true"/>
@@ -69,9 +87,12 @@ defmodule Surface.Components.Form.CheckboxTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <Checkbox form="user" field="admin" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_admin" name="user[admin]" phx-focus="my_focus" type="checkbox" value="true"/>
@@ -79,9 +100,12 @@ defmodule Surface.Components.Form.CheckboxTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <Checkbox form="user" field="admin" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_admin" name="user[admin]" phx-capture-click="my_click" type="checkbox" value="true"/>
@@ -89,9 +113,12 @@ defmodule Surface.Components.Form.CheckboxTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <Checkbox form="user" field="admin" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_admin" name="user[admin]" phx-keydown="my_keydown" type="checkbox" value="true"/>
@@ -99,9 +126,12 @@ defmodule Surface.Components.Form.CheckboxTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <Checkbox form="user" field="admin" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Checkbox form="user" field="admin" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_admin" name="user[admin]" phx-keyup="my_keyup" type="checkbox" value="true"/>
@@ -117,9 +147,12 @@ defmodule Surface.Components.Form.CheckboxConfigTest do
 
   test ":default_class config" do
     using_config Checkbox, default_class: "default_class" do
-      code = """
-      <Checkbox />
-      """
+      code =
+        quote do
+          ~H"""
+          <Checkbox />
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/color_input_test.exs
+++ b/test/components/form/color_input_test.exs
@@ -5,9 +5,12 @@ defmodule Surface.Components.Form.ColorInputTest do
   alias Surface.Components.Form.ColorInput, warn: false
 
   test "empty input" do
-    code = """
-    <ColorInput form="user" field="color" />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" type="color"/>
@@ -15,9 +18,12 @@ defmodule Surface.Components.Form.ColorInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <ColorInput form="user" field="color" value="mycolor" />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" value="mycolor" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" type="color" value="mycolor"/>
@@ -25,25 +31,34 @@ defmodule Surface.Components.Form.ColorInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <ColorInput form="user" field="color" class="input"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" class="input"/>
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <ColorInput form="user" field="color" class="input primary"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" class="input primary"/>
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <ColorInput form="user" field="color" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[color]" type="color"/>
@@ -51,9 +66,12 @@ defmodule Surface.Components.Form.ColorInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <ColorInput form="user" field="color" value="mycolor" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" value="mycolor" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="color" value="mycolor"/>
@@ -61,9 +79,12 @@ defmodule Surface.Components.Form.ColorInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <ColorInput form="user" field="color" value="mycolor" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" value="mycolor" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="color" value="mycolor"/>
@@ -71,9 +92,12 @@ defmodule Surface.Components.Form.ColorInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <ColorInput form="user" field="color" value="mycolor" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" value="mycolor" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="color" value="mycolor"/>
@@ -81,9 +105,12 @@ defmodule Surface.Components.Form.ColorInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <ColorInput form="user" field="color" value="mycolor" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" value="mycolor" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="color" value="mycolor"/>
@@ -91,9 +118,12 @@ defmodule Surface.Components.Form.ColorInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <ColorInput form="user" field="color" value="mycolor" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <ColorInput form="user" field="color" value="mycolor" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="color" value="mycolor"/>
@@ -109,9 +139,12 @@ defmodule Surface.Components.Form.ColorInputConfigTest do
 
   test ":default_class config" do
     using_config ColorInput, default_class: "default_class" do
-      code = """
-      <ColorInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ColorInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/date_input_test.exs
+++ b/test/components/form/date_input_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.DateInputTest do
   alias Surface.Components.Form.DateInput, warn: false
 
   test "empty input" do
-    code = """
-    <DateInput form="user" field="birthday" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="birthday" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_birthday" name="user[birthday]" type="date"/>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.DateInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <DateInput form="user" field="birthday" value="mybirthday" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="birthday" value="mybirthday" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_birthday" name="user[birthday]" type="date" value="mybirthday"/>
@@ -26,25 +32,34 @@ defmodule Surface.Components.Form.DateInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <DateInput form="user" field="birthday" class="input"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="birthday" class="input"/>
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <DateInput form="user" field="birthday" class="input primary"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="birthday" class="input primary"/>
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <DateInput form="user" field="birthday" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="birthday" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[birthday]" type="date"/>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.DateInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <DateInput form="user" field="color" value="mybirthday" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="color" value="mybirthday" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="date" value="mybirthday"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.DateInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <DateInput form="user" field="color" value="mybirthday" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="color" value="mybirthday" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="date" value="mybirthday"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.DateInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <DateInput form="user" field="color" value="mybirthday" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="color" value="mybirthday" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="date" value="mybirthday"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.DateInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <DateInput form="user" field="color" value="mybirthday" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="color" value="mybirthday" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="date" value="mybirthday"/>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.DateInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <DateInput form="user" field="color" value="mybirthday" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateInput form="user" field="color" value="mybirthday" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="date" value="mybirthday"/>
@@ -110,9 +140,12 @@ defmodule Surface.Components.Form.DateInputConfigTest do
 
   test ":default_class config" do
     using_config DateInput, default_class: "default_class" do
-      code = """
-      <DateInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <DateInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/datetime_local_input_test.exs
+++ b/test/components/form/datetime_local_input_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   import ComponentTestHelper
 
   test "empty input" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="order_completed_at" name="order[completed_at]" type="datetime-local"/>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="order_completed_at" name="order[completed_at]" type="datetime-local" value="2020-05-05T19:30"/>
@@ -26,25 +32,34 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" class="input"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" class="input"/>
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" class="input primary"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" class="input primary"/>
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="order[completed_at]" type="datetime-local"/>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="order_completed_at" name="order[completed_at]" phx-blur="my_blur" type="datetime-local" value="2020-05-05T19:30"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="order_completed_at" name="order[completed_at]" phx-focus="my_focus" type="datetime-local" value="2020-05-05T19:30"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="order_completed_at" name="order[completed_at]" phx-capture-click="my_click" type="datetime-local" value="2020-05-05T19:30"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="order_completed_at" name="order[completed_at]" phx-keydown="my_keydown" type="datetime-local" value="2020-05-05T19:30"/>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeLocalInput form="order" field="completed_at" value="2020-05-05T19:30" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="order_completed_at" name="order[completed_at]" phx-keyup="my_keyup" type="datetime-local" value="2020-05-05T19:30"/>
@@ -110,9 +140,12 @@ defmodule Surface.Components.Form.DateTimeLocalInputConfigTest do
 
   test ":default_class config" do
     using_config DateTimeLocalInput, default_class: "default_class" do
-      code = """
-      <DateTimeLocalInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <DateTimeLocalInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/datetime_select_test.exs
+++ b/test/components/form/datetime_select_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
   alias Surface.Components.Form.DateTimeSelect, warn: false
 
   test "datetime select" do
-    code = """
-    <DateTimeSelect form="user" field="born_at" />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect form="user" field="born_at" />
+        """
+      end
 
     content = render_live(code)
 
@@ -20,11 +23,14 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
   end
 
   test "with form context" do
-    code = """
-    <Form for={{ :user }}>
-      <DateTimeSelect field={{ :born_at }} />
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :user }}>
+          <DateTimeSelect field={{ :born_at }} />
+        </Form>
+        """
+      end
 
     content = render_live(code)
 
@@ -37,9 +43,12 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
   end
 
   test "setting the value as map" do
-    code = """
-    <DateTimeSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
+        """
+      end
 
     content = render_live(code)
 
@@ -52,9 +61,12 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
   end
 
   test "setting the value as tuple" do
-    code = """
-    <DateTimeSelect form="user" field="born_at" value={{ { {2020, 10, 9}, {2, 11, 13} } }} opts={{ second: [] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect form="user" field="born_at" value={{ { {2020, 10, 9}, {2, 11, 13} } }} opts={{ second: [] }} />
+        """
+      end
 
     content = render_live(code)
 
@@ -67,9 +79,12 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
   end
 
   test "passing other options" do
-    code = """
-    <DateTimeSelect form="user" field="born_at" opts={{ second: [] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect form="user" field="born_at" opts={{ second: [] }} />
+        """
+      end
 
     content = render_live(code)
 

--- a/test/components/form/email_input_test.exs
+++ b/test/components/form/email_input_test.exs
@@ -5,9 +5,12 @@ defmodule Surface.Components.Form.EmailInputTest do
   alias Surface.Components.Form.EmailInput, warn: false
 
   test "empty input" do
-    code = """
-    <EmailInput form="user" field="email" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="email" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_email" name="user[email]" type="email"/>
@@ -15,9 +18,12 @@ defmodule Surface.Components.Form.EmailInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <EmailInput form="user" field="email" value="admin@gmail.com" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="email" value="admin@gmail.com" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_email" name="user[email]" type="email" value="admin@gmail.com"/>
@@ -25,25 +31,34 @@ defmodule Surface.Components.Form.EmailInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <EmailInput form="user" field="email" value="admin@gmail.com" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="email" value="admin@gmail.com" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <EmailInput form="user" field="email" value="admin@gmail.com" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="email" value="admin@gmail.com" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <EmailInput form="user" field="email" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="email" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[email]" type="email"/>
@@ -51,9 +66,12 @@ defmodule Surface.Components.Form.EmailInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <EmailInput form="user" field="color" value="admin@gmail.com" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="color" value="admin@gmail.com" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="email" value="admin@gmail.com"/>
@@ -61,9 +79,12 @@ defmodule Surface.Components.Form.EmailInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <EmailInput form="user" field="color" value="admin@gmail.com" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="color" value="admin@gmail.com" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="email" value="admin@gmail.com"/>
@@ -71,9 +92,12 @@ defmodule Surface.Components.Form.EmailInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <EmailInput form="user" field="color" value="admin@gmail.com" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="color" value="admin@gmail.com" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="email" value="admin@gmail.com"/>
@@ -81,9 +105,12 @@ defmodule Surface.Components.Form.EmailInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <EmailInput form="user" field="color" value="admin@gmail.com" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="color" value="admin@gmail.com" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="email" value="admin@gmail.com"/>
@@ -91,9 +118,12 @@ defmodule Surface.Components.Form.EmailInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <EmailInput form="user" field="color" value="admin@gmail.com" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <EmailInput form="user" field="color" value="admin@gmail.com" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="email" value="admin@gmail.com"/>
@@ -109,9 +139,12 @@ defmodule Surface.Components.Form.EmailInputConfigTest do
 
   test ":default_class config" do
     using_config EmailInput, default_class: "default_class" do
-      code = """
-      <EmailInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <EmailInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/file_input_test.exs
+++ b/test/components/form/file_input_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.FileInputTest do
   alias Surface.Components.Form.FileInput, warn: false
 
   test "empty input" do
-    code = """
-    <FileInput form="user" field="picture" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_picture" name="user[picture]" type="file"/>
@@ -16,11 +19,14 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "with form context" do
-    code = """
-    <Form for={{ :user }} opts={{ csrf_token: "test", multipart: true }}>
-      <FileInput field={{ :picture }} />
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :user }} opts={{ csrf_token: "test", multipart: true }}>
+          <FileInput field={{ :picture }} />
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" enctype="multipart/form-data" method="post">\
@@ -31,9 +37,12 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <FileInput form="user" field="picture" value="path/to/file" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" value="path/to/file" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_picture" name="user[picture]" type="file" value="path/to/file"/>
@@ -41,25 +50,34 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <FileInput form="user" field="picture" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <FileInput form="user" field="picture" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <FileInput form="user" field="picture" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[picture]" type="file"/>
@@ -67,9 +85,12 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <FileInput form="user" field="picture" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_picture" name="user[picture]" phx-blur="my_blur" type="file"/>
@@ -77,9 +98,12 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <FileInput form="user" field="picture" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_picture" name="user[picture]" phx-focus="my_focus" type="file"/>
@@ -87,9 +111,12 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <FileInput form="user" field="picture" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_picture" name="user[picture]" phx-capture-click="my_click" type="file"/>
@@ -97,9 +124,12 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <FileInput form="user" field="picture" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_picture" name="user[picture]" phx-keydown="my_keydown" type="file"/>
@@ -107,9 +137,12 @@ defmodule Surface.Components.Form.FileInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <FileInput form="user" field="picture" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <FileInput form="user" field="picture" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_picture" name="user[picture]" phx-keyup="my_keyup" type="file"/>
@@ -125,9 +158,12 @@ defmodule Surface.Components.Form.FileInputConfigTest do
 
   test ":default_class config" do
     using_config FileInput, default_class: "default_class" do
-      code = """
-      <FileInput />
-      """
+      code =
+        quote do
+          ~H"""
+          <FileInput />
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/hidden_input_test.exs
+++ b/test/components/form/hidden_input_test.exs
@@ -5,9 +5,12 @@ defmodule Surface.Components.Form.HiddenInputTest do
   alias Surface.Components.Form.HiddenInput, warn: false
 
   test "empty input" do
-    code = """
-    <HiddenInput form="user" field="token" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="token" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_token" name="user[token]" type="hidden"/>
@@ -15,9 +18,12 @@ defmodule Surface.Components.Form.HiddenInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <HiddenInput form="user" field="token" value="token" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="token" value="token" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_token" name="user[token]" type="hidden" value="token"/>
@@ -25,25 +31,34 @@ defmodule Surface.Components.Form.HiddenInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <HiddenInput form="user" field="token" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="token" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <HiddenInput form="user" field="token" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="token" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <HiddenInput form="user" field="token" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="token" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[token]" type="hidden"/>
@@ -51,9 +66,12 @@ defmodule Surface.Components.Form.HiddenInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <HiddenInput form="user" field="color" value="token" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="color" value="token" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="hidden" value="token"/>
@@ -61,9 +79,12 @@ defmodule Surface.Components.Form.HiddenInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <HiddenInput form="user" field="color" value="token" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="color" value="token" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="hidden" value="token"/>
@@ -71,9 +92,12 @@ defmodule Surface.Components.Form.HiddenInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <HiddenInput form="user" field="color" value="token" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="color" value="token" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="hidden" value="token"/>
@@ -81,9 +105,12 @@ defmodule Surface.Components.Form.HiddenInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <HiddenInput form="user" field="color" value="token" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="color" value="token" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="hidden" value="token"/>
@@ -91,9 +118,12 @@ defmodule Surface.Components.Form.HiddenInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <HiddenInput form="user" field="color" value="token" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <HiddenInput form="user" field="color" value="token" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="hidden" value="token"/>

--- a/test/components/form/hidden_inputs_test.exs
+++ b/test/components/form/hidden_inputs_test.exs
@@ -8,13 +8,16 @@ defmodule Surface.Components.Form.HiddenInputsTest do
   import ComponentTestHelper
 
   test "using generated form received as slot props" do
-    code = """
-    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
-      <Inputs for={{ :children }} :let={{ form: f }}>
-        <HiddenInputs for={{ f }} />
-      </Inputs>
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+          <Inputs for={{ :children }} :let={{ form: f }}>
+            <HiddenInputs for={{ f }} />
+          </Inputs>
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post">\
@@ -24,13 +27,16 @@ defmodule Surface.Components.Form.HiddenInputsTest do
   end
 
   test "using generated form stored in the Form context" do
-    code = """
-    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
-      <Inputs for={{ :children }}>
-        <HiddenInputs />
-      </Inputs>
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+          <Inputs for={{ :children }}>
+            <HiddenInputs />
+          </Inputs>
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post">\

--- a/test/components/form/inputs_test.exs
+++ b/test/components/form/inputs_test.exs
@@ -8,14 +8,17 @@ defmodule Surface.Components.Form.InputsTest do
   import ComponentTestHelper
 
   test "using generated form received as slot props" do
-    code = """
-    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
-      <Inputs for={{ :children }} :let={{ form: f }}>
-        <TextInput form={{ f }} field="name" />
-        <TextInput form={{ f }} field="email" />
-      </Inputs>
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+          <Inputs for={{ :children }} :let={{ form: f }}>
+            <TextInput form={{ f }} field="name" />
+            <TextInput form={{ f }} field="email" />
+          </Inputs>
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
@@ -26,14 +29,17 @@ defmodule Surface.Components.Form.InputsTest do
   end
 
   test "using generated form stored in the Form context" do
-    code = """
-    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
-      <Inputs for={{ :children }}>
-        <TextInput field="name" />
-        <TextInput field="email" />
-      </Inputs>
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+          <Inputs for={{ :children }}>
+            <TextInput field="name" />
+            <TextInput field="email" />
+          </Inputs>
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\
@@ -44,14 +50,17 @@ defmodule Surface.Components.Form.InputsTest do
   end
 
   test "passing extra opts" do
-    code = """
-    <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
-      <Inputs for={{ :children }} opts={{ as: "custom_name"}}>
-        <TextInput field="name" />
-        <TextInput field="email" />
-      </Inputs>
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :parent }} opts={{ csrf_token: "test" }}>
+          <Inputs for={{ :children }} opts={{ as: "custom_name"}}>
+            <TextInput field="name" />
+            <TextInput field="email" />
+          </Inputs>
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/>\

--- a/test/components/form/multiple_select_test.exs
+++ b/test/components/form/multiple_select_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.MultipleSelectTest do
   import ComponentTestHelper
 
   test "emtpy multiple select" do
-    code = """
-    <MultipleSelect form="user" field="roles" />
-    """
+    code =
+      quote do
+        ~H"""
+        <MultipleSelect form="user" field="roles" />
+        """
+      end
 
     assert render_live(code) =~ """
            <select id="user_roles" multiple="" name="user[roles][]"></select>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.MultipleSelectTest do
   end
 
   test "setting the options" do
-    code = """
-    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <select id="user_roles" multiple="" name="user[roles][]">\
@@ -29,25 +35,34 @@ defmodule Surface.Components.Form.MultipleSelectTest do
   end
 
   test "setting the class" do
-    code = """
-    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} class="select" />
-    """
+    code =
+      quote do
+        ~H"""
+        <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} class="select" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="select"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} class="select primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} class="select primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="select primary"/
   end
 
   test "passing other options" do
-    code = """
-    <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} opts={{ selected: ["admin"] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} opts={{ selected: ["admin"] }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <select id="user_roles" multiple="" name="user[roles][]">\
@@ -66,9 +81,12 @@ defmodule Surface.Components.Form.MultipleSelectConfigTest do
 
   test ":default_class config" do
     using_config MultipleSelect, default_class: "default_class" do
-      code = """
-      <MultipleSelect />
-      """
+      code =
+        quote do
+          ~H"""
+          <MultipleSelect />
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/number_input_test.exs
+++ b/test/components/form/number_input_test.exs
@@ -5,9 +5,12 @@ defmodule Surface.Components.Form.NumberInputTest do
   alias Surface.Components.Form.NumberInput, warn: false
 
   test "empty input" do
-    code = """
-    <NumberInput form="user" field="age" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="age" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_age" name="user[age]" type="number"/>
@@ -15,9 +18,12 @@ defmodule Surface.Components.Form.NumberInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <NumberInput form="user" field="age" value="33" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="age" value="33" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_age" name="user[age]" type="number" value="33"/>
@@ -25,25 +31,34 @@ defmodule Surface.Components.Form.NumberInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <NumberInput form="user" field="age" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="age" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <NumberInput form="user" field="age" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="age" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <NumberInput form="user" field="age" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="age" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[age]" type="number"/>
@@ -51,9 +66,12 @@ defmodule Surface.Components.Form.NumberInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <NumberInput form="user" field="color" value="33" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="color" value="33" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="number" value="33"/>
@@ -61,9 +79,12 @@ defmodule Surface.Components.Form.NumberInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <NumberInput form="user" field="color" value="33" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="color" value="33" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="number" value="33"/>
@@ -71,9 +92,12 @@ defmodule Surface.Components.Form.NumberInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <NumberInput form="user" field="color" value="33" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="color" value="33" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="number" value="33"/>
@@ -81,9 +105,12 @@ defmodule Surface.Components.Form.NumberInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <NumberInput form="user" field="color" value="33" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="color" value="33" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="number" value="33"/>
@@ -91,9 +118,12 @@ defmodule Surface.Components.Form.NumberInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <NumberInput form="user" field="color" value="33" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <NumberInput form="user" field="color" value="33" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="number" value="33"/>
@@ -109,9 +139,12 @@ defmodule Surface.Components.Form.NumberInputConfigTest do
 
   test ":default_class config" do
     using_config NumberInput, default_class: "default_class" do
-      code = """
-      <NumberInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <NumberInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/options_for_select_test.exs
+++ b/test/components/form/options_for_select_test.exs
@@ -6,17 +6,23 @@ defmodule Surface.Components.Form.OptionsForSelectTest do
   import ComponentTestHelper
 
   test "empty options" do
-    code = """
-    <OptionsForSelect />
-    """
+    code =
+      quote do
+        ~H"""
+        <OptionsForSelect />
+        """
+      end
 
     assert render_live(code) == "\n"
   end
 
   test "setting the options" do
-    code = """
-    <OptionsForSelect options={{ ["Admin": "admin", "User": "user"] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <OptionsForSelect options={{ ["Admin": "admin", "User": "user"] }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <option value="admin">Admin</option>\
@@ -25,9 +31,12 @@ defmodule Surface.Components.Form.OptionsForSelectTest do
   end
 
   test "passing selected value" do
-    code = """
-    <OptionsForSelect options={{ ["Admin": "admin", "User": "user"] }} selected={{ "admin" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <OptionsForSelect options={{ ["Admin": "admin", "User": "user"] }} selected={{ "admin" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <option value="admin" selected="selected">Admin</option>\
@@ -36,9 +45,12 @@ defmodule Surface.Components.Form.OptionsForSelectTest do
   end
 
   test "passing multiple selected values" do
-    code = """
-    <OptionsForSelect options={{ ["Admin": "admin", "User": "user"] }} selected={{ ["admin", "user"] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <OptionsForSelect options={{ ["Admin": "admin", "User": "user"] }} selected={{ ["admin", "user"] }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <option value="admin" selected="selected">Admin</option>\

--- a/test/components/form/password_input_test.exs
+++ b/test/components/form/password_input_test.exs
@@ -5,9 +5,12 @@ defmodule Surface.Components.Form.PasswordInputTest do
   alias Surface.Components.Form.PasswordInput, warn: false
 
   test "empty input" do
-    code = """
-    <PasswordInput form="user" field="password" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="password" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_password" name="user[password]" type="password"/>
@@ -15,9 +18,12 @@ defmodule Surface.Components.Form.PasswordInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <PasswordInput form="user" field="password" value="secret" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="password" value="secret" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_password" name="user[password]" type="password" value="secret"/>
@@ -25,25 +31,34 @@ defmodule Surface.Components.Form.PasswordInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <PasswordInput form="user" field="password" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="password" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <PasswordInput form="user" field="password" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="password" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <PasswordInput form="user" field="password" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="password" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[password]" type="password"/>
@@ -51,9 +66,12 @@ defmodule Surface.Components.Form.PasswordInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <PasswordInput form="user" field="color" value="secret" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="color" value="secret" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="password" value="secret"/>
@@ -61,9 +79,12 @@ defmodule Surface.Components.Form.PasswordInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <PasswordInput form="user" field="color" value="secret" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="color" value="secret" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="password" value="secret"/>
@@ -71,9 +92,12 @@ defmodule Surface.Components.Form.PasswordInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <PasswordInput form="user" field="color" value="secret" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="color" value="secret" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="password" value="secret"/>
@@ -81,9 +105,12 @@ defmodule Surface.Components.Form.PasswordInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <PasswordInput form="user" field="color" value="secret" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="color" value="secret" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="password" value="secret"/>
@@ -91,9 +118,12 @@ defmodule Surface.Components.Form.PasswordInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <PasswordInput form="user" field="color" value="secret" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <PasswordInput form="user" field="color" value="secret" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="password" value="secret"/>
@@ -109,9 +139,12 @@ defmodule Surface.Components.Form.PasswordInputConfigTest do
 
   test ":default_class config" do
     using_config PasswordInput, default_class: "default_class" do
-      code = """
-      <PasswordInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <PasswordInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/radio_button_test.exs
+++ b/test/components/form/radio_button_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.RadioButtonTest do
   import ComponentTestHelper
 
   test "radio" do
-    code = """
-    <RadioButton form="user" field="role" value="admin"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin"/>
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_role_admin" name="user[role]" type="radio" value="admin"/>
@@ -16,25 +19,34 @@ defmodule Surface.Components.Form.RadioButtonTest do
   end
 
   test "setting the class" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" class="radio" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" class="radio" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="radio"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" class="radio primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" class="radio primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="radio primary"/
   end
 
   test "passing other options" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[role]" type="radio" value="admin"/>
@@ -42,9 +54,12 @@ defmodule Surface.Components.Form.RadioButtonTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_role_admin" name="user[role]" phx-blur="my_blur" type="radio" value="admin"/>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.RadioButtonTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_role_admin" name="user[role]" phx-focus="my_focus" type="radio" value="admin"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.RadioButtonTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_role_admin" name="user[role]" phx-capture-click="my_click" type="radio" value="admin"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.RadioButtonTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_role_admin" name="user[role]" phx-keydown="my_keydown" type="radio" value="admin"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.RadioButtonTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <RadioButton form="user" field="role" value="admin" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RadioButton form="user" field="role" value="admin" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_role_admin" name="user[role]" phx-keyup="my_keyup" type="radio" value="admin"/>
@@ -100,9 +127,12 @@ defmodule Surface.Components.Form.RadioButtonConfigTest do
 
   test ":default_class config" do
     using_config RadioButton, default_class: "default_class" do
-      code = """
-      <RadioButton/>
-      """
+      code =
+        quote do
+          ~H"""
+          <RadioButton/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/range_input_test.exs
+++ b/test/components/form/range_input_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   alias Surface.Components.Form.RangeInput, warn: false
 
   test "empty input" do
-    code = """
-    <RangeInput form="volume" field="percent"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="volume" field="percent"/>
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="volume_percent" name="volume[percent]" type="range"/>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "setting min, max and step" do
-    code = """
-    <RangeInput form="volume" field="percent" min="0" max="100" step="50"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="volume" field="percent" min="0" max="100" step="50"/>
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="volume_percent" max="100" min="0" name="volume[percent]" step="50" type="range"/>
@@ -26,9 +32,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <RangeInput form="volume" field="percent" min="0" max="100" value="25"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="volume" field="percent" min="0" max="100" value="25"/>
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="volume_percent" max="100" min="0" name="volume[percent]" type="range" value="25"/>
@@ -36,25 +45,34 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <RangeInput form="volume" field="percent" min="0" max="100" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="volume" field="percent" min="0" max="100" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <RangeInput form="volume" field="percent" min="0" max="100" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="volume" field="percent" min="0" max="100" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <RangeInput form="volume" field="percent" min="0" max="100" opts={{ id: "myid" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="volume" field="percent" min="0" max="100" opts={{ id: "myid" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="myid" max="100" min="0" name="volume[percent]" type="range"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <RangeInput form="user" field="color" value="25" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="user" field="color" value="25" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="range" value="25"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <RangeInput form="user" field="color" value="25" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="user" field="color" value="25" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="range" value="25"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <RangeInput form="user" field="color" value="25" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="user" field="color" value="25" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="range" value="25"/>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <RangeInput form="user" field="color" value="25" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="user" field="color" value="25" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="range" value="25"/>
@@ -102,9 +132,12 @@ defmodule Surface.Components.Form.RangeInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <RangeInput form="user" field="color" value="25" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <RangeInput form="user" field="color" value="25" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="range" value="25"/>
@@ -120,9 +153,12 @@ defmodule Surface.Components.Form.RangeInputConfigTest do
 
   test ":default_class config" do
     using_config RangeInput, default_class: "default_class" do
-      code = """
-      <RangeInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <RangeInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/reset_test.exs
+++ b/test/components/form/reset_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.ResetTest do
   import ComponentTestHelper
 
   test "empty reset" do
-    code = """
-    <Reset />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset />
+        """
+      end
 
     assert render_live(code) =~ """
            <input type="reset" value="Reset"/>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.ResetTest do
   end
 
   test "setting the value" do
-    code = """
-    <Reset value="ResetTheForm" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset value="ResetTheForm" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input type="reset" value="ResetTheForm"/>
@@ -26,25 +32,34 @@ defmodule Surface.Components.Form.ResetTest do
   end
 
   test "setting the class" do
-    code = """
-    <Reset class="button" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset class="button" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="button"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <Reset class="button primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset class="button primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="button primary"/
   end
 
   test "passing other options" do
-    code = """
-    <Reset opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" type="reset" value="Reset"/>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.ResetTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <Reset value="ResetTheForm" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset value="ResetTheForm" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input phx-blur="my_blur" type="reset" value="ResetTheForm"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.ResetTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <Reset value="ResetTheForm" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset value="ResetTheForm" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input phx-focus="my_focus" type="reset" value="ResetTheForm"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.ResetTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <Reset value="ResetTheForm" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset value="ResetTheForm" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input phx-capture-click="my_click" type="reset" value="ResetTheForm"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.ResetTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <Reset value="ResetTheForm" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset value="ResetTheForm" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input phx-keydown="my_keydown" type="reset" value="ResetTheForm"/>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.ResetTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <Reset value="ResetTheForm" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Reset value="ResetTheForm" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input phx-keyup="my_keyup" type="reset" value="ResetTheForm"/>

--- a/test/components/form/search_input_test.exs
+++ b/test/components/form/search_input_test.exs
@@ -5,9 +5,12 @@ defmodule Surface.Components.Form.SearchInputTest do
   alias Surface.Components.Form.SearchInput, warn: false
 
   test "empty input" do
-    code = """
-    <SearchInput form="song" field="title" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="song" field="title" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="song_title" name="song[title]" type="search"/>
@@ -15,9 +18,12 @@ defmodule Surface.Components.Form.SearchInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <SearchInput form="song" field="title" value="mytitle" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="song" field="title" value="mytitle" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="song_title" name="song[title]" type="search" value="mytitle"/>
@@ -25,25 +31,34 @@ defmodule Surface.Components.Form.SearchInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <SearchInput form="song" field="title" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="song" field="title" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <SearchInput form="song" field="title" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="song" field="title" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <SearchInput form="song" field="title" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="song" field="title" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="song[title]" type="search"/>
@@ -51,9 +66,12 @@ defmodule Surface.Components.Form.SearchInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <SearchInput form="user" field="color" value="mytitle" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="user" field="color" value="mytitle" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="search" value="mytitle"/>
@@ -61,9 +79,12 @@ defmodule Surface.Components.Form.SearchInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <SearchInput form="user" field="color" value="mytitle" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="user" field="color" value="mytitle" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="search" value="mytitle"/>
@@ -71,9 +92,12 @@ defmodule Surface.Components.Form.SearchInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <SearchInput form="user" field="color" value="mytitle" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="user" field="color" value="mytitle" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="search" value="mytitle"/>
@@ -81,9 +105,12 @@ defmodule Surface.Components.Form.SearchInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <SearchInput form="user" field="color" value="mytitle" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="user" field="color" value="mytitle" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="search" value="mytitle"/>
@@ -91,9 +118,12 @@ defmodule Surface.Components.Form.SearchInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <SearchInput form="user" field="color" value="mytitle" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <SearchInput form="user" field="color" value="mytitle" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="search" value="mytitle"/>
@@ -109,9 +139,12 @@ defmodule Surface.Components.Form.SearchInputConfigTest do
 
   test ":default_class config" do
     using_config SearchInput, default_class: "default_class" do
-      code = """
-      <SearchInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <SearchInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/select_test.exs
+++ b/test/components/form/select_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.SelectTest do
   import ComponentTestHelper
 
   test "empty select" do
-    code = """
-    <Select form="user" field="role" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Select form="user" field="role" />
+        """
+      end
 
     assert render_live(code) =~ """
            <select id="user_role" name="user[role]"></select>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.SelectTest do
   end
 
   test "setting the options" do
-    code = """
-    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <select id="user_role" name="user[role]">\
@@ -29,25 +35,34 @@ defmodule Surface.Components.Form.SelectTest do
   end
 
   test "setting the class" do
-    code = """
-    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} class="select" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} class="select" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="select"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} class="select primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} class="select primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="select primary"/
   end
 
   test "passing other options" do
-    code = """
-    <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} opts={{ prompt: "Pick a role" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} opts={{ prompt: "Pick a role" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <select id="user_role" name="user[role]">\
@@ -67,9 +82,12 @@ defmodule Surface.Components.Form.SelectConfigTest do
 
   test ":default_class config" do
     using_config Select, default_class: "default_class" do
-      code = """
-      <Select />
-      """
+      code =
+        quote do
+          ~H"""
+          <Select />
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/submit_test.exs
+++ b/test/components/form/submit_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.SubmitTest do
   alias Surface.Components.Form.Submit, warn: false
 
   test "label only" do
-    code = """
-    <Submit label="Submit" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Submit label="Submit" />
+        """
+      end
 
     assert render_live(code) =~ """
            <button type="submit">Submit</button>
@@ -16,25 +19,34 @@ defmodule Surface.Components.Form.SubmitTest do
   end
 
   test "with class" do
-    code = """
-    <Submit label="Submit" class="button" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Submit label="Submit" class="button" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="button"/
   end
 
   test "with multiple classes" do
-    code = """
-    <Submit label="Submit" class="button primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <Submit label="Submit" class="button primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="button primary"/
   end
 
   test "with options" do
-    code = """
-    <Submit label="Submit" class="btn" opts={{ id: "submit-btn" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <Submit label="Submit" class="btn" opts={{ id: "submit-btn" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <button class="btn" id="submit-btn" type="submit">Submit</button>
@@ -42,11 +54,14 @@ defmodule Surface.Components.Form.SubmitTest do
   end
 
   test "with children" do
-    code = """
-    <Submit class="btn">
-      <span>Submit</span>
-    </Submit>
-    """
+    code =
+      quote do
+        ~H"""
+        <Submit class="btn">
+          <span>Submit</span>
+        </Submit>
+        """
+      end
 
     assert render_live(code) =~ """
            <button class="btn" type="submit"><span>Submit</span></button>

--- a/test/components/form/telephone_input_test.exs
+++ b/test/components/form/telephone_input_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   alias Surface.Components.Form.TelephoneInput, warn: false
 
   test "empty input" do
-    code = """
-    <TelephoneInput form="user" field="phone" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="phone" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_phone" name="user[phone]" type="tel"/>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <TelephoneInput form="user" field="phone" value="phone_no" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="phone" value="phone_no" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_phone" name="user[phone]" type="tel" value="phone_no"/>
@@ -26,25 +32,34 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <TelephoneInput form="user" field="phone" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="phone" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <TelephoneInput form="user" field="phone" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="phone" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <TelephoneInput form="user" field="phone" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="phone" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[phone]" type="tel"/>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <TelephoneInput form="user" field="color" value="phone_no" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="color" value="phone_no" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="tel" value="phone_no"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <TelephoneInput form="user" field="color" value="phone_no" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="color" value="phone_no" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="tel" value="phone_no"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <TelephoneInput form="user" field="color" value="phone_no" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="color" value="phone_no" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="tel" value="phone_no"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <TelephoneInput form="user" field="color" value="phone_no" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="color" value="phone_no" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="tel" value="phone_no"/>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.TelephoneInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <TelephoneInput form="user" field="color" value="phone_no" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TelephoneInput form="user" field="color" value="phone_no" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="tel" value="phone_no"/>
@@ -110,9 +140,12 @@ defmodule Surface.Components.Form.TelephoneInputConfigTest do
 
   test ":default_class config" do
     using_config TelephoneInput, default_class: "default_class" do
-      code = """
-      <TelephoneInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <TelephoneInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -5,9 +5,12 @@ defmodule Surface.Components.Form.TextInputTest do
   alias Surface.Components.Form.TextInput, warn: false
 
   test "empty input" do
-    code = """
-    <TextInput form="user" field="name" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="name" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_name" name="user[name]" type="text"/>
@@ -15,9 +18,12 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <TextInput form="user" field="name" value="Max" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="name" value="Max" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_name" name="user[name]" type="text" value="Max"/>
@@ -25,25 +31,34 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <TextInput form="user" field="name" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="name" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <TextInput form="user" field="name" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="name" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <TextInput form="user" field="name" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="name" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[name]" type="text"/>
@@ -51,9 +66,12 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <TextInput form="user" field="color" value="Max" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="text" value="Max"/>
@@ -61,9 +79,12 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <TextInput form="user" field="color" value="Max" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="text" value="Max"/>
@@ -71,9 +92,12 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <TextInput form="user" field="color" value="Max" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="text" value="Max"/>
@@ -81,9 +105,12 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <TextInput form="user" field="color" value="Max" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="text" value="Max"/>
@@ -91,9 +118,12 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <TextInput form="user" field="color" value="Max" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="text" value="Max"/>
@@ -109,9 +139,12 @@ defmodule Surface.Components.Form.TextInputConfigTest do
 
   test ":default_class config" do
     using_config TextInput, default_class: "default_class" do
-      code = """
-      <TextInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <TextInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/textarea_test.exs
+++ b/test/components/form/textarea_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.TextAreaTest do
   import ComponentTestHelper
 
   test "empty textarea" do
-    code = """
-    <TextArea form="user" field="summary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea id="user_summary" name="user[summary]">\n</textarea>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.TextAreaTest do
   end
 
   test "setting the value" do
-    code = """
-    <TextArea form="user" field="summary" value="some content" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" value="some content" />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea id="user_summary" name="user[summary]">\nsome content</textarea>
@@ -26,25 +32,34 @@ defmodule Surface.Components.Form.TextAreaTest do
   end
 
   test "setting the class" do
-    code = """
-    <TextArea form="user" field="summary" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <TextArea form="user" field="summary" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <TextArea form="user" field="summary" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea autofocus="autofocus" id="myid" name="user[summary]">\n</textarea>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.TextAreaTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <TextArea form="user" field="summary" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea id="user_summary" name="user[summary]" phx-blur="my_blur">\n</textarea>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.TextAreaTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <TextArea form="user" field="summary" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea id="user_summary" name="user[summary]" phx-focus="my_focus">\n</textarea>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.TextAreaTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <TextArea form="user" field="summary" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea id="user_summary" name="user[summary]" phx-capture-click="my_click">\n</textarea>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.TextAreaTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <TextArea form="user" field="summary" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea id="user_summary" name="user[summary]" phx-keydown="my_keydown">\n</textarea>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.TextAreaTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <TextArea form="user" field="summary" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TextArea form="user" field="summary" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <textarea id="user_summary" name="user[summary]" phx-keyup="my_keyup">\n</textarea>
@@ -110,9 +140,12 @@ defmodule Surface.Components.Form.TextAreaConfigTest do
 
   test ":default_class config" do
     using_config TextArea, default_class: "default_class" do
-      code = """
-      <TextArea/>
-      """
+      code =
+        quote do
+          ~H"""
+          <TextArea/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/time_input_test.exs
+++ b/test/components/form/time_input_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.TimeInputTest do
   alias Surface.Components.Form.TimeInput, warn: false
 
   test "empty input" do
-    code = """
-    <TimeInput form="user" field="time" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="time" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_time" name="user[time]" type="time"/>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.TimeInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <TimeInput form="user" field="time" value="23:59:59" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="time" value="23:59:59" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_time" name="user[time]" type="time" value="23:59:59"/>
@@ -26,25 +32,34 @@ defmodule Surface.Components.Form.TimeInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <TimeInput form="user" field="time" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="time" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <TimeInput form="user" field="time" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="time" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <TimeInput form="user" field="time" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="time" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[time]" type="time"/>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.TimeInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <TimeInput form="user" field="color" value="23:59:59" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="color" value="23:59:59" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="time" value="23:59:59"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.TimeInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <TimeInput form="user" field="color" value="23:59:59" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="color" value="23:59:59" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="time" value="23:59:59"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.TimeInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <TimeInput form="user" field="color" value="23:59:59" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="color" value="23:59:59" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="time" value="23:59:59"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.TimeInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <TimeInput form="user" field="color" value="23:59:59" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="color" value="23:59:59" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="time" value="23:59:59"/>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.TimeInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <TimeInput form="user" field="color" value="23:59:59" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeInput form="user" field="color" value="23:59:59" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="time" value="23:59:59"/>
@@ -110,9 +140,12 @@ defmodule Surface.Components.Form.TimeInputConfigTest do
 
   test ":default_class config" do
     using_config TimeInput, default_class: "default_class" do
-      code = """
-      <TimeInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <TimeInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form/time_select_test.exs
+++ b/test/components/form/time_select_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.TimeSelectTest do
   alias Surface.Components.Form.TimeSelect, warn: false
 
   test "datetime select" do
-    code = """
-    <TimeSelect form="alarm" field="time" />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeSelect form="alarm" field="time" />
+        """
+      end
 
     content = render_live(code)
 
@@ -17,11 +20,14 @@ defmodule Surface.Components.Form.TimeSelectTest do
   end
 
   test "with form context" do
-    code = """
-    <Form for={{ :alarm }}>
-      <TimeSelect field={{ :time }} />
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :alarm }}>
+          <TimeSelect field={{ :time }} />
+        </Form>
+        """
+      end
 
     content = render_live(code)
 
@@ -31,9 +37,12 @@ defmodule Surface.Components.Form.TimeSelectTest do
   end
 
   test "setting the value as map" do
-    code = """
-    <TimeSelect form="alarm" field="time" value={{ %{hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeSelect form="alarm" field="time" value={{ %{hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
+        """
+      end
 
     content = render_live(code)
 
@@ -43,9 +52,12 @@ defmodule Surface.Components.Form.TimeSelectTest do
   end
 
   test "setting the value as tuple" do
-    code = """
-    <TimeSelect form="alarm" field="time" value={{ {2, 11, 13} }} opts={{ second: [] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeSelect form="alarm" field="time" value={{ {2, 11, 13} }} opts={{ second: [] }} />
+        """
+      end
 
     content = render_live(code)
 
@@ -55,9 +67,12 @@ defmodule Surface.Components.Form.TimeSelectTest do
   end
 
   test "passing other options" do
-    code = """
-    <TimeSelect form="alarm" field="time" opts={{ second: [] }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <TimeSelect form="alarm" field="time" opts={{ second: [] }} />
+        """
+      end
 
     content = render_live(code)
 

--- a/test/components/form/url_input_test.exs
+++ b/test/components/form/url_input_test.exs
@@ -6,9 +6,12 @@ defmodule Surface.Components.Form.UrlInputTest do
   alias Surface.Components.Form.UrlInput, warn: false
 
   test "empty input" do
-    code = """
-    <UrlInput form="user" field="website" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="website" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_website" name="user[website]" type="url"/>
@@ -16,9 +19,12 @@ defmodule Surface.Components.Form.UrlInputTest do
   end
 
   test "setting the value" do
-    code = """
-    <UrlInput form="user" field="website" value="https://github.com/msaraiva/surface" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="website" value="https://github.com/msaraiva/surface" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_website" name="user[website]" type="url" value="https://github.com/msaraiva/surface"/>
@@ -26,25 +32,34 @@ defmodule Surface.Components.Form.UrlInputTest do
   end
 
   test "setting the class" do
-    code = """
-    <UrlInput form="user" field="website" class="input" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="website" class="input" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code = """
-    <UrlInput form="user" field="website" class="input primary" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="website" class="input primary" />
+        """
+      end
 
     assert render_live(code) =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code = """
-    <UrlInput form="user" field="website" opts={{ id: "myid", autofocus: "autofocus" }} />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="website" opts={{ id: "myid", autofocus: "autofocus" }} />
+        """
+      end
 
     assert render_live(code) =~ """
            <input autofocus="autofocus" id="myid" name="user[website]" type="url"/>
@@ -52,9 +67,12 @@ defmodule Surface.Components.Form.UrlInputTest do
   end
 
   test "blur event with parent live view as target" do
-    code = """
-    <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" blur="my_blur" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" blur="my_blur" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="url" value="https://github.com/msaraiva/surface"/>
@@ -62,9 +80,12 @@ defmodule Surface.Components.Form.UrlInputTest do
   end
 
   test "focus event with parent live view as target" do
-    code = """
-    <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" focus="my_focus" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" focus="my_focus" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="url" value="https://github.com/msaraiva/surface"/>
@@ -72,9 +93,12 @@ defmodule Surface.Components.Form.UrlInputTest do
   end
 
   test "capture click event with parent live view as target" do
-    code = """
-    <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" capture_click="my_click" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" capture_click="my_click" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="url" value="https://github.com/msaraiva/surface"/>
@@ -82,9 +106,12 @@ defmodule Surface.Components.Form.UrlInputTest do
   end
 
   test "keydown event with parent live view as target" do
-    code = """
-    <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" keydown="my_keydown" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" keydown="my_keydown" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="url" value="https://github.com/msaraiva/surface"/>
@@ -92,9 +119,12 @@ defmodule Surface.Components.Form.UrlInputTest do
   end
 
   test "keyup event with parent live view as target" do
-    code = """
-    <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" keyup="my_keyup" />
-    """
+    code =
+      quote do
+        ~H"""
+        <UrlInput form="user" field="color" value="https://github.com/msaraiva/surface" keyup="my_keyup" />
+        """
+      end
 
     assert render_live(code) =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="url" value="https://github.com/msaraiva/surface"/>
@@ -110,9 +140,12 @@ defmodule Surface.Components.Form.UrlInputConfigTest do
 
   test ":default_class config" do
     using_config UrlInput, default_class: "default_class" do
-      code = """
-      <UrlInput/>
-      """
+      code =
+        quote do
+          ~H"""
+          <UrlInput/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/form_test.exs
+++ b/test/components/form_test.exs
@@ -25,10 +25,13 @@ defmodule Surface.Components.FormTest do
   end
 
   test "form as an atom" do
-    code = """
-    <Form for={{:user}} action="#" opts={{ csrf_token: "test" }}>
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{:user}} action="#" opts={{ csrf_token: "test" }}>
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post"><input name="_csrf_token" type="hidden" value="test"/></form>
@@ -36,11 +39,14 @@ defmodule Surface.Components.FormTest do
   end
 
   test "form with a text input using context" do
-    code = """
-    <Form for={{:user}} action="#" opts={{ csrf_token: "test" }}>
-      <TextInput field="name" />
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{:user}} action="#" opts={{ csrf_token: "test" }}>
+          <TextInput field="name" />
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post">\
@@ -69,10 +75,13 @@ defmodule Surface.Components.FormTest do
   end
 
   test "form with events" do
-    code = """
-    <Form for={{:user}} action="#" change="change" submit="sumit">
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{:user}} action="#" change="change" submit="sumit">
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ """
            <form action="#" method="post" phx-change="change" phx-submit="sumit">\

--- a/test/components/label_test.exs
+++ b/test/components/label_test.exs
@@ -7,45 +7,60 @@ defmodule Surface.Components.LabelTest do
   import ComponentTestHelper
 
   test "generates a <label> passing any opts to the underlying label/3" do
-    code = """
-    <Label opts={{ id: "my_id" }}/>
-    """
+    code =
+      quote do
+        ~H"""
+        <Label opts={{ id: "my_id" }}/>
+        """
+      end
 
     assert render_live(code) =~ ~r[<label (.+) id="my_id">(.+)</label>]
   end
 
   test "property class" do
-    code = """
-    <Label class={{ :label }}/>
-    """
+    code =
+      quote do
+        ~H"""
+        <Label class={{ :label }}/>
+        """
+      end
 
     assert render_live(code) =~ ~S(class="label")
   end
 
   test "property multiple classes" do
-    code = """
-    <Label class={{ :label, :primary }}/>
-    """
+    code =
+      quote do
+        ~H"""
+        <Label class={{ :label, :primary }}/>
+        """
+      end
 
     assert render_live(code) =~ ~S(class="label primary")
   end
 
   test "properties form and field" do
-    code = """
-    <Label form="user" field="name"/>
-    """
+    code =
+      quote do
+        ~H"""
+        <Label form="user" field="name"/>
+        """
+      end
 
     assert render_live(code) =~ ~S(<label for="user_name">Name</label>)
   end
 
   test "use context's form and field by default" do
-    code = """
-    <Form for={{ :user }}>
-      <Field name="name">
-        <Label/>
-      </Field>
-    </Form>
-    """
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :user }}>
+          <Field name="name">
+            <Label/>
+          </Field>
+        </Form>
+        """
+      end
 
     assert render_live(code) =~ ~S(<label for="user_name">Name</label>)
   end
@@ -59,9 +74,12 @@ defmodule Surface.Components.Form.LabelConfigTest do
 
   test ":default_class config" do
     using_config Label, default_class: "default_class" do
-      code = """
-      <Label/>
-      """
+      code =
+        quote do
+          ~H"""
+          <Label/>
+          """
+        end
 
       assert render_live(code) =~ ~r/class="default_class"/
     end

--- a/test/components/link_test.exs
+++ b/test/components/link_test.exs
@@ -23,9 +23,12 @@ defmodule Surface.Components.LinkTest do
 
   describe "Without LiveView" do
     test "creates a link with label" do
-      code = """
-      <Link label="user" to="/users/1" />
-      """
+      code =
+        quote do
+          ~H"""
+          <Link label="user" to="/users/1" />
+          """
+        end
 
       assert render_live(code) =~ """
              <a href="/users/1">user</a>
@@ -33,9 +36,12 @@ defmodule Surface.Components.LinkTest do
     end
 
     test "creates a link without label" do
-      code = """
-      <Link to="/users/1" />
-      """
+      code =
+        quote do
+          ~H"""
+          <Link to="/users/1" />
+          """
+        end
 
       assert render_live(code) =~ """
              <a href="/users/1"></a>
@@ -43,9 +49,12 @@ defmodule Surface.Components.LinkTest do
     end
 
     test "creates a link with default slot" do
-      code = """
-      <Link to="/users/1"><span>user</span></Link>
-      """
+      code =
+        quote do
+          ~H"""
+          <Link to="/users/1"><span>user</span></Link>
+          """
+        end
 
       assert render_live(code) =~ """
              <a href="/users/1"><span>user</span></a>
@@ -53,9 +62,12 @@ defmodule Surface.Components.LinkTest do
     end
 
     test "setting the class" do
-      code = """
-      <Link label="user" to="/users/1" class="link" />
-      """
+      code =
+        quote do
+          ~H"""
+          <Link label="user" to="/users/1" class="link" />
+          """
+        end
 
       assert render_live(code) =~ """
              <a class="link" href="/users/1">user</a>
@@ -63,9 +75,12 @@ defmodule Surface.Components.LinkTest do
     end
 
     test "setting multiple classes" do
-      code = """
-      <Link label="user" to="/users/1" class="link primary" />
-      """
+      code =
+        quote do
+          ~H"""
+          <Link label="user" to="/users/1" class="link primary" />
+          """
+        end
 
       assert render_live(code) =~ """
              <a class="link primary" href="/users/1">user</a>
@@ -73,9 +88,12 @@ defmodule Surface.Components.LinkTest do
     end
 
     test "passing other options" do
-      code = """
-      <Link label="user" to="/users/1" class="link" opts={{ method: :delete, data: [confirm: "Really?"], csrf_token: "token" }} />
-      """
+      code =
+        quote do
+          ~H"""
+          <Link label="user" to="/users/1" class="link" opts={{ method: :delete, data: [confirm: "Really?"], csrf_token: "token" }} />
+          """
+        end
 
       assert render_live(code) =~ """
              <a class="link" data-confirm="Really?" data-csrf="token" data-method="delete" data-to="/users/1" href="/users/1" rel="nofollow">user</a>
@@ -83,9 +101,12 @@ defmodule Surface.Components.LinkTest do
     end
 
     test "click event with parent live view as target" do
-      code = """
-      <Link to="/users/1" click="my_click" />
-      """
+      code =
+        quote do
+          ~H"""
+          <Link to="/users/1" click="my_click" />
+          """
+        end
 
       assert render_live(code) =~ """
              <a href="/users/1" phx-click="my_click"></a>
@@ -93,9 +114,12 @@ defmodule Surface.Components.LinkTest do
     end
 
     test "click event with @myself as target" do
-      code = """
-      <ComponentWithLink id="comp"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ComponentWithLink id="comp"/>
+          """
+        end
 
       assert render_live(code) =~ """
              <div data-phx-component="1"><a href="/users/1" phx-click="my_click" phx-target="1"></a></div>

--- a/test/components/live_patch_test.exs
+++ b/test/components/live_patch_test.exs
@@ -23,51 +23,69 @@ defmodule Surface.Components.LivePatchTest do
 
   describe "Without LiveView" do
     test "creates a link with label" do
-      code = """
-      <LivePatch label="user" to="/users/1" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LivePatch label="user" to="/users/1" />
+          """
+        end
 
       assert render_live(code) =~ actual_content("user", to: "/users/1")
     end
 
     test "creates a link without label" do
-      code = """
-      <LivePatch to="/users/1" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LivePatch to="/users/1" />
+          """
+        end
 
       assert render_live(code) =~ actual_content(to: "/users/1")
     end
 
     test "creates a link with default slot" do
-      code = """
-      <LivePatch to="/users/1"><span>user</span></LivePatch>
-      """
+      code =
+        quote do
+          ~H"""
+          <LivePatch to="/users/1"><span>user</span></LivePatch>
+          """
+        end
 
       assert render_live(code) =~ actual_content({:safe, "<span>user</span>"}, to: "/users/1")
     end
 
     test "setting the class" do
-      code = """
-      <LivePatch label="user" to="/users/1" class="link" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LivePatch label="user" to="/users/1" class="link" />
+          """
+        end
 
       assert render_live(code) =~
                actual_content("user", to: "/users/1", class: "link")
     end
 
     test "setting multiple classes" do
-      code = """
-      <LivePatch label="user" to="/users/1" class="link primary" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LivePatch label="user" to="/users/1" class="link primary" />
+          """
+        end
 
       assert render_live(code) =~
                actual_content("user", to: "/users/1", class: "link primary")
     end
 
     test "passing other options" do
-      code = """
-      <LivePatch label="user" to="/users/1" class="link" opts={{ method: :delete, "data-confirm": "Really?", "csrf-token": "token" }} />
-      """
+      code =
+        quote do
+          ~H"""
+          <LivePatch label="user" to="/users/1" class="link" opts={{ method: :delete, "data-confirm": "Really?", "csrf-token": "token" }} />
+          """
+        end
 
       rendered = render_live(code)
 

--- a/test/components/live_redirect_test.exs
+++ b/test/components/live_redirect_test.exs
@@ -23,51 +23,69 @@ defmodule Surface.Components.LiveRedirectTest do
 
   describe "Without LiveView" do
     test "creates a link with label" do
-      code = """
-      <LiveRedirect label="user" to="/users/1" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LiveRedirect label="user" to="/users/1" />
+          """
+        end
 
       assert render_live(code) =~ actual_content("user", to: "/users/1")
     end
 
     test "creates a link without label" do
-      code = """
-      <LiveRedirect to="/users/1" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LiveRedirect to="/users/1" />
+          """
+        end
 
       assert render_live(code) =~ actual_content(to: "/users/1")
     end
 
     test "creates a link with default slot" do
-      code = """
-      <LiveRedirect to="/users/1"><span>user</span></LiveRedirect>
-      """
+      code =
+        quote do
+          ~H"""
+          <LiveRedirect to="/users/1"><span>user</span></LiveRedirect>
+          """
+        end
 
       assert render_live(code) =~ actual_content({:safe, "<span>user</span>"}, to: "/users/1")
     end
 
     test "setting the class" do
-      code = """
-      <LiveRedirect label="user" to="/users/1" class="link" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LiveRedirect label="user" to="/users/1" class="link" />
+          """
+        end
 
       assert render_live(code) =~
                actual_content("user", to: "/users/1", class: "link")
     end
 
     test "setting multiple classes" do
-      code = """
-      <LiveRedirect label="user" to="/users/1" class="link primary" />
-      """
+      code =
+        quote do
+          ~H"""
+          <LiveRedirect label="user" to="/users/1" class="link primary" />
+          """
+        end
 
       assert render_live(code) =~
                actual_content("user", to: "/users/1", class: "link primary")
     end
 
     test "passing other options" do
-      code = """
-      <LiveRedirect label="user" to="/users/1" class="link" opts={{ method: :delete, "data-confirm": "Really?", "csrf-token": "token" }} />
-      """
+      code =
+        quote do
+          ~H"""
+          <LiveRedirect label="user" to="/users/1" class="link" opts={{ method: :delete, "data-confirm": "Really?", "csrf-token": "token" }} />
+          """
+        end
 
       rendered = render_live(code)
 

--- a/test/components/markdown_test.exs
+++ b/test/components/markdown_test.exs
@@ -103,14 +103,16 @@ defmodule Surface.Components.MarkdownSyncTest do
   describe "config" do
     test ":default_class config" do
       using_config Markdown, default_class: "content" do
-        html =
-          render_live("""
-          <#Markdown>
-            # Head 1
-          </#Markdown>
-          """)
+        code =
+          quote do
+            ~H"""
+            <#Markdown>
+              # Head 1
+            </#Markdown>
+            """
+          end
 
-        assert html =~ """
+        assert render_live(code) =~ """
                <div class="content"><h1>
                Head 1</h1></div>
                """
@@ -119,14 +121,16 @@ defmodule Surface.Components.MarkdownSyncTest do
 
     test "override the :default_class config" do
       using_config Markdown, default_class: "content" do
-        html =
-          render_live("""
-          <#Markdown class="markdown">
-            # Head 1
-          </#Markdown>
-          """)
+        code =
+          quote do
+            ~H"""
+            <#Markdown class="markdown">
+              # Head 1
+            </#Markdown>
+            """
+          end
 
-        assert html =~ """
+        assert render_live(code) =~ """
                <div class="markdown"><h1>
                Head 1</h1></div>
                """
@@ -135,16 +139,18 @@ defmodule Surface.Components.MarkdownSyncTest do
 
     test ":default_opts config" do
       using_config Markdown, default_opts: [code_class_prefix: "language-"] do
-        html =
-          render_live(~S"""
-          <#Markdown>
-            ```elixir
-            var = 1
-            ```
-          </#Markdown>
-          """)
+        code =
+          quote do
+            ~H"""
+            <#Markdown>
+              ```elixir
+              var = 1
+              ```
+            </#Markdown>
+            """
+          end
 
-        assert html =~ """
+        assert render_live(code) =~ """
                <div><pre><code class="elixir language-elixir">var = 1</code></pre></div>
                """
       end
@@ -152,30 +158,34 @@ defmodule Surface.Components.MarkdownSyncTest do
 
     test "property opts gets merged with global config :opts (overriding existing keys)" do
       using_config Markdown, default_opts: [code_class_prefix: "language-", smartypants: false] do
-        html =
-          render_live("""
-          <#Markdown>
-            "Elixir"
-          </#Markdown>
-          """)
+        code =
+          quote do
+            ~H"""
+            <#Markdown>
+              "Elixir"
+            </#Markdown>
+            """
+          end
 
-        assert html =~ """
+        assert render_live(code) =~ """
                <div><p>
                &quot;Elixir&quot;</p></div>
                """
 
-        html =
-          render_live("""
-          <#Markdown opts={{ smartypants: true }}>
-            "Elixir"
+        code =
+          quote do
+            ~H"""
+            <#Markdown opts={{ smartypants: true }}>
+              "Elixir"
 
-            ```elixir
-            code
-            ```
-          </#Markdown>
-          """)
+              ```elixir
+              code
+              ```
+            </#Markdown>
+            """
+          end
 
-        assert html =~
+        assert render_live(code) =~
                  """
                  <div><p>
                  “Elixir”</p><pre><code class="elixir language-elixir">code</code></pre></div>
@@ -188,12 +198,15 @@ defmodule Surface.Components.MarkdownSyncTest do
     test "do not accept runtime expressions" do
       assigns = %{class: "markdown"}
 
-      code = """
-      <#Markdown
-        class={{ @class }}>
-        # Head 1
-      </#Markdown>
-      """
+      code =
+        quote do
+          ~H"""
+          <#Markdown
+            class={{ @class }}>
+            # Head 1
+          </#Markdown>
+          """
+        end
 
       message = ~r"""
       code:2: invalid value for property "class"
@@ -215,13 +228,16 @@ defmodule Surface.Components.MarkdownSyncTest do
     test "show parsing errors/warnings at the right line" do
       assigns = %{class: "markdown"}
 
-      code = """
-      <#Markdown>
-        Text
-        Text `code
-        Text
-      </#Markdown>
-      """
+      code =
+        quote do
+          ~H"""
+          <#Markdown>
+            Text
+            Text `code
+            Text
+          </#Markdown>
+          """
+        end
 
       output =
         capture_io(:standard_error, fn ->

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -84,11 +84,14 @@ defmodule ContextTest do
   end
 
   test "pass context to child component" do
-    code = """
-    <Outer>
-      <Inner/>
-    </Outer>
-    """
+    code =
+      quote do
+        ~H"""
+        <Outer>
+          <Inner/>
+        </Outer>
+        """
+      end
 
     assert render_live(code) =~ """
            <span id="field">field from Outer</span>\
@@ -96,11 +99,14 @@ defmodule ContextTest do
   end
 
   test "pass context to child component using :as option" do
-    code = """
-    <Outer>
-      <InnerWithOptionAs/>
-    </Outer>
-    """
+    code =
+      quote do
+        ~H"""
+        <Outer>
+          <InnerWithOptionAs/>
+        </Outer>
+        """
+      end
 
     assert render_live(code) =~ """
            <div><span>field from Outer</span></div>
@@ -108,11 +114,14 @@ defmodule ContextTest do
   end
 
   test "pass context down the tree of components" do
-    code = """
-    <Outer>
-      <InnerWrapper />
-    </Outer>
-    """
+    code =
+      quote do
+        ~H"""
+        <Outer>
+          <InnerWrapper />
+        </Outer>
+        """
+      end
 
     assert render_live(code) =~ """
            <span id="field">field from Outer</span>\
@@ -120,11 +129,14 @@ defmodule ContextTest do
   end
 
   test "context assingns are scoped by their parent components" do
-    code = """
-    <Outer>
-      <InnerWrapper/>
-    </Outer>
-    """
+    code =
+      quote do
+        ~H"""
+        <Outer>
+          <InnerWrapper/>
+        </Outer>
+        """
+      end
 
     assert render_live(code) =~ """
            <span id="field">field from Outer</span>\
@@ -133,12 +145,15 @@ defmodule ContextTest do
   end
 
   test "reset context after the component" do
-    code = """
-    <Outer>
-      <Inner/>
-    </Outer>
-    <RenderContext/>
-    """
+    code =
+      quote do
+        ~H"""
+        <Outer>
+          <Inner/>
+        </Outer>
+        <RenderContext/>
+        """
+      end
 
     assert render_live(code) =~ """
            Context: %{}
@@ -146,27 +161,33 @@ defmodule ContextTest do
   end
 
   test "pass context to named slots" do
-    code = """
-    <OuterWithNamedSlots>
-      <template slot="my_slot">
-        <Context get={{ field: field }}>
-          {{ field }}
-        </Context>
-      </template>
-    </OuterWithNamedSlots>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithNamedSlots>
+          <template slot="my_slot">
+            <Context get={{ field: field }}>
+              {{ field }}
+            </Context>
+          </template>
+        </OuterWithNamedSlots>
+        """
+      end
 
     assert render_live(code) =~ "field from OuterWithNamedSlots"
   end
 
   describe "validate property :get" do
     test "raise compile error when passing invalid bindings" do
-      code = """
-      <Context
-        get={{ ContextTest.Outer, field: [field] }}>
-        {{ field }}
-      </Context>
-      """
+      code =
+        quote do
+          ~H"""
+          <Context
+            get={{ ContextTest.Outer, field: [field] }}>
+            {{ field }}
+          </Context>
+          """
+        end
 
       message = """
       code:2: invalid value for property "get". expected a scope \
@@ -181,12 +202,15 @@ defmodule ContextTest do
     end
 
     test "raise compile error when passing no bindings" do
-      code = """
-      <Context
-        get={{ ContextTest.Outer }}>
-        {{ field }}
-      </Context>
-      """
+      code =
+        quote do
+          ~H"""
+          <Context
+            get={{ ContextTest.Outer }}>
+            {{ field }}
+          </Context>
+          """
+        end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "get"/, fn ->
         render_live(code)
@@ -194,12 +218,15 @@ defmodule ContextTest do
     end
 
     test "raise compile error when passing invalid scope" do
-      code = """
-      <Context
-        get={{ 123, field: field }}>
-        {{ field }}
-      </Context>
-      """
+      code =
+        quote do
+          ~H"""
+          <Context
+            get={{ 123, field: field }}>
+            {{ field }}
+          </Context>
+          """
+        end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "get"/, fn ->
         render_live(code)
@@ -209,12 +236,15 @@ defmodule ContextTest do
 
   describe "validate property :put" do
     test "raise compile error when passing invalid values" do
-      code = """
-      <Context
-        put={{ ContextTest.Outer, 123 }}>
-        <slot/>
-      </Context>
-      """
+      code =
+        quote do
+          ~H"""
+          <Context
+            put={{ ContextTest.Outer, 123 }}>
+            <slot/>
+          </Context>
+          """
+        end
 
       message = """
       code:2: invalid value for property "put". expected a scope \
@@ -229,12 +259,15 @@ defmodule ContextTest do
     end
 
     test "raise compile error when passing no values" do
-      code = """
-      <Context
-        put={{ ContextTest.Outer }}>
-        <slot/>
-      </Context>
-      """
+      code =
+        quote do
+          ~H"""
+          <Context
+            put={{ ContextTest.Outer }}>
+            <slot/>
+          </Context>
+          """
+        end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "put"/, fn ->
         render_live(code)
@@ -242,12 +275,15 @@ defmodule ContextTest do
     end
 
     test "raise compile error when passing invalid scope" do
-      code = """
-      <Context
-        put={{ 123, field: field }}>
-        <slot/>
-      </Context>
-      """
+      code =
+        quote do
+          ~H"""
+          <Context
+            put={{ 123, field: field }}>
+            <slot/>
+          </Context>
+          """
+        end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "put"/, fn ->
         render_live(code)

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -34,9 +34,12 @@ defmodule Surface.DirectivesTest do
     test "passing keyword list of props" do
       assigns = %{}
 
-      code = """
-      <DivWithProps :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
-      """
+      code =
+        quote do
+          ~H"""
+          <DivWithProps :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div class="text-xs block">
@@ -48,9 +51,12 @@ defmodule Surface.DirectivesTest do
     test "static props override dynamic props" do
       assigns = %{}
 
-      code = """
-      <DivWithProps content="static content" :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
-      """
+      code =
+        quote do
+          ~H"""
+          <DivWithProps content="static content" :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div class="text-xs block">
@@ -62,9 +68,12 @@ defmodule Surface.DirectivesTest do
     test "using an assign" do
       assigns = %{opts: %{class: "text-xs", hidden: false, content: "dynamic props content"}}
 
-      code = """
-      <DivWithProps :props={{ @opts }} />
-      """
+      code =
+        quote do
+          ~H"""
+          <DivWithProps :props={{ @opts }} />
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div class="text-xs block">
@@ -160,11 +169,14 @@ defmodule Surface.DirectivesTest do
     test "using multiple modifiers" do
       assigns = %{items: [:a, :b]}
 
-      code = """
-      <div :for.index.with_index={{ {i, j} <- @items }}>
-        i: {{ i }}, j: {{ j }}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <div :for.index.with_index={{ {i, j} <- @items }}>
+            i: {{ i }}, j: {{ j }}
+          </div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>
@@ -178,12 +190,15 @@ defmodule Surface.DirectivesTest do
     test "raise compile error for unknown modifiers" do
       assigns = %{items: [%{id: 1, name: "First"}]}
 
-      code = """
-      <br/>
-      <div :for.unknown={{ @items }}>
-        Index: {{ index }}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <br/>
+          <div :for.unknown={{ @items }}>
+            Index: {{ index }}
+          </div>
+          """
+        end
 
       message = """
       code:2: unknown modifier "unknown" for directive :for\
@@ -197,12 +212,15 @@ defmodule Surface.DirectivesTest do
     test "raise compile error for modifiers with multiple clauses" do
       assigns = %{a: [1, 2], b: [1, 2]}
 
-      code = """
-      <br/>
-      <div :for.with_index={{ i <- a, j <- b }}>
-        Index: {{ index }}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <br/>
+          <div :for.with_index={{ i <- a, j <- b }}>
+            Index: {{ index }}
+          </div>
+          """
+        end
 
       message = """
       code:2: cannot apply modifier "with_index" on generators with multiple clauses\
@@ -218,11 +236,14 @@ defmodule Surface.DirectivesTest do
     test "in components" do
       assigns = %{items: [1, 2]}
 
-      code = """
-      <Div :for={{ i <- @items }}>
-        Item: {{i}}
-      </Div>
-      """
+      code =
+        quote do
+          ~H"""
+          <Div :for={{ i <- @items }}>
+            Item: {{i}}
+          </Div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>
@@ -236,11 +257,14 @@ defmodule Surface.DirectivesTest do
     test "in html tags" do
       assigns = %{items: [1, 2]}
 
-      code = """
-      <div :for={{ i <- @items }}>
-        Item: {{i}}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <div :for={{ i <- @items }}>
+            Item: {{i}}
+          </div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>
@@ -266,12 +290,15 @@ defmodule Surface.DirectivesTest do
     test "with larger generator expression" do
       assigns = %{items1: [1, 2], items2: [3, 4]}
 
-      code = """
-      <div :for={{ i1 <- @items1, i2 <- @items2, i1 < 4 }}>
-        Item1: {{i1}}
-        Item2: {{i2}}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <div :for={{ i1 <- @items1, i2 <- @items2, i1 < 4 }}>
+            Item1: {{i1}}
+            Item2: {{i2}}
+          </div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>
@@ -296,11 +323,14 @@ defmodule Surface.DirectivesTest do
     test "with_index modifier" do
       assigns = %{items: [1, 2]}
 
-      code = """
-      <div :for.with_index={{ {item, index} <- @items }}>
-        Item: {{ item }}, Index: {{ index }}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <div :for.with_index={{ {item, index} <- @items }}>
+            Item: {{ item }}, Index: {{ index }}
+          </div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>
@@ -314,11 +344,14 @@ defmodule Surface.DirectivesTest do
     test "index modifier with generator" do
       assigns = %{items: [1, 2]}
 
-      code = """
-      <div :for.index={{ index <- @items }}>
-        Index: {{ index }}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <div :for.index={{ index <- @items }}>
+            Index: {{ index }}
+          </div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>
@@ -332,11 +365,14 @@ defmodule Surface.DirectivesTest do
     test "index modifier with list" do
       assigns = %{items: [1, 2]}
 
-      code = """
-      <div :for.index={{ @items }}>
-        Index: {{ index }}
-      </div>
-      """
+      code =
+        quote do
+          ~H"""
+          <div :for.index={{ @items }}>
+            Index: {{ index }}
+          </div>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              <div>
@@ -352,14 +388,17 @@ defmodule Surface.DirectivesTest do
     test "in components" do
       assigns = %{show: true, dont_show: false}
 
-      code = """
-      <Div :if={{ @show }}>
-        Show
-      </Div>
-      <Div :if={{ @dont_show }}>
-        Dont's show
-      </Div>
-      """
+      code =
+        quote do
+          ~H"""
+          <Div :if={{ @show }}>
+            Show
+          </Div>
+          <Div :if={{ @dont_show }}>
+            Dont's show
+          </Div>
+          """
+        end
 
       assert render_live(code, assigns) == """
              <div>
@@ -523,9 +562,12 @@ defmodule Surface.DirectivesSyncTest do
         }
       }
 
-      code = """
-      <DivWithProps :props={{ @opts }} />
-      """
+      code =
+        quote do
+          ~H"""
+          <DivWithProps :props={{ @opts }} />
+          """
+        end
 
       {:warn, message} = capture_warning(code, assigns)
 

--- a/test/live_component_events_test.exs
+++ b/test/live_component_events_test.exs
@@ -94,11 +94,14 @@ defmodule Surface.EventsTest do
   end
 
   test "handle event in parent component" do
-    code = """
-    <div>
-      <Panel id="panel_id"/>
-    </div>
-    """
+    code =
+      quote do
+        ~H"""
+        <div>
+          <Panel id="panel_id"/>
+        </div>
+        """
+      end
 
     assert render_live(code) =~ """
            <button data-phx-component="2" phx-click="click" phx-target="1"\
@@ -106,11 +109,14 @@ defmodule Surface.EventsTest do
   end
 
   test "handle event locally" do
-    code = """
-    <div>
-      <Button id="button_id"/>
-    </div>
-    """
+    code =
+      quote do
+        ~H"""
+        <div>
+          <Button id="button_id"/>
+        </div>
+        """
+      end
 
     assert render_live(code) =~ """
            <button data-phx-component="1" phx-click="click" phx-target="1"\
@@ -118,11 +124,14 @@ defmodule Surface.EventsTest do
   end
 
   test "override target" do
-    code = """
-    <div>
-      <Button id="button_id" click={{ %{name: "ok", target: "#comp"} }}/>
-    </div>
-    """
+    code =
+      quote do
+        ~H"""
+        <div>
+          <Button id="button_id" click={{ %{name: "ok", target: "#comp"} }}/>
+        </div>
+        """
+      end
 
     assert render_live(code) =~ """
            phx-click="ok" phx-target="#comp"\
@@ -135,30 +144,39 @@ defmodule Surface.EventsTest do
     """
 
     # Event name as string
-    code = """
-    <div>
-      <Button id="button_id" click={{ "ok", target: "#comp" }}/>
-    </div>
-    """
+    code =
+      quote do
+        ~H"""
+        <div>
+          <Button id="button_id" click={{ "ok", target: "#comp" }}/>
+        </div>
+        """
+      end
 
     assert render_live(code) =~ expected
 
     # Event name as atom
-    code = """
-    <div>
-      <Button id="button_id" click={{ :ok, target: "#comp" }}/>
-    </div>
-    """
+    code =
+      quote do
+        ~H"""
+        <div>
+          <Button id="button_id" click={{ :ok, target: "#comp" }}/>
+        </div>
+        """
+      end
 
     assert render_live(code) =~ expected
   end
 
   test "passing event as nil does not render phx-*" do
-    code = """
-    <div>
-      <Button id="button_id" click={{ nil }}/>
-    </div>
-    """
+    code =
+      quote do
+        ~H"""
+        <div>
+          <Button id="button_id" click={{ nil }}/>
+        </div>
+        """
+      end
 
     html = render_live(code)
 
@@ -168,11 +186,14 @@ defmodule Surface.EventsTest do
   end
 
   test "raise error when passing an :event into a phx-* binding" do
-    code = """
-    <div>
-      <ButtonWithInvalidEvent id="button_id" click={{ "ok" }}/>
-    </div>
-    """
+    code =
+      quote do
+        ~H"""
+        <div>
+          <ButtonWithInvalidEvent id="button_id" click={{ "ok" }}/>
+        </div>
+        """
+      end
 
     message = """
     invalid value for "phx-click". LiveView bindings only accept values \

--- a/test/live_component_test.exs
+++ b/test/live_component_test.exs
@@ -99,11 +99,14 @@ defmodule LiveComponentTest do
   end
 
   test "render content without slot props" do
-    code = """
-    <InfoProviderWithoutSlotProps>
-      <span>Hi there!</span>
-    </InfoProviderWithoutSlotProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <InfoProviderWithoutSlotProps>
+          <span>Hi there!</span>
+        </InfoProviderWithoutSlotProps>
+        """
+      end
 
     assert render_live(code) =~ """
            <div><span>Hi there!</span></div>
@@ -111,11 +114,14 @@ defmodule LiveComponentTest do
   end
 
   test "render content with slot props" do
-    code = """
-    <InfoProvider :let={{ info: my_info }}>
-      <span>{{ my_info }}</span>
-    </InfoProvider>
-    """
+    code =
+      quote do
+        ~H"""
+        <InfoProvider :let={{ info: my_info }}>
+          <span>{{ my_info }}</span>
+        </InfoProvider>
+        """
+      end
 
     assert render_live(code) =~ """
            <div><span>Hi there!</span></div>
@@ -123,9 +129,12 @@ defmodule LiveComponentTest do
   end
 
   test "render stateful component with event" do
-    code = """
-    <LiveComponentWithEvent event="click-event" id="button" />
-    """
+    code =
+      quote do
+        ~H"""
+        <LiveComponentWithEvent event="click-event" id="button" />
+        """
+      end
 
     assert render_live(code) =~ """
            <button data-phx-component=\"1\" phx-click=\"click-event\"></button>

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -94,9 +94,12 @@ defmodule Surface.PropertiesTest do
 
   describe "string" do
     test "passing a string with interpolation" do
-      code = """
-      <StringProp label="begin {{ @a }} {{ @b }} end"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <StringProp label="begin {{ @a }} {{ @b }} end"/>
+          """
+        end
 
       assert render_live(code, %{a: 1, b: "two"}) =~ "begin 1 two end"
     end
@@ -104,9 +107,12 @@ defmodule Surface.PropertiesTest do
 
   describe "keyword" do
     test "passing a keyword list" do
-      code = """
-      <KeywordProp prop={{ [option1: 1, option2: 2] }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <KeywordProp prop={{ [option1: 1, option2: 2] }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              Keyword?: true
@@ -116,9 +122,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list without brackets" do
-      code = """
-      <KeywordProp prop={{ option1: 1, option2: 2 }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <KeywordProp prop={{ option1: 1, option2: 2 }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              Keyword?: true
@@ -130,9 +139,12 @@ defmodule Surface.PropertiesTest do
     test "passing a keyword list as an expression" do
       assigns = %{submit: [option1: 1, option2: 2]}
 
-      code = """
-      <KeywordProp prop={{ @submit }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <KeywordProp prop={{ @submit }}/>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              Keyword?: true
@@ -142,9 +154,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "validate invalid literals at compile-time" do
-      code = """
-      <KeywordProp prop="some string"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <KeywordProp prop="some string"/>
+          """
+        end
 
       message =
         ~S(code:1: invalid value for property "prop". Expected a :keyword, got: "some string".)
@@ -157,9 +172,12 @@ defmodule Surface.PropertiesTest do
     test "validate invalid values at runtime" do
       assigns = %{var: 1}
 
-      code = """
-      <KeywordProp prop={{ @var }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <KeywordProp prop={{ @var }}/>
+          """
+        end
 
       message = """
       invalid value for property "prop". Expected a :keyword, got: 1.
@@ -175,9 +193,12 @@ defmodule Surface.PropertiesTest do
 
   describe "map" do
     test "passing a map" do
-      code = """
-      <MapProp prop={{ %{option1: 1, option2: 2} }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <MapProp prop={{ %{option1: 1, option2: 2} }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              Map?: true
@@ -187,9 +208,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list" do
-      code = """
-      <MapProp prop={{ [option1: 1, option2: 2] }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <MapProp prop={{ [option1: 1, option2: 2] }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              Map?: true
@@ -199,9 +223,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list without brackets" do
-      code = """
-      <MapProp prop={{ option1: 1, option2: 2 }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <MapProp prop={{ option1: 1, option2: 2 }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              Map?: true
@@ -213,9 +240,12 @@ defmodule Surface.PropertiesTest do
     test "passing a map as an expression" do
       assigns = %{submit: %{option1: 1, option2: 2}}
 
-      code = """
-      <MapProp prop={{ @submit }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <MapProp prop={{ @submit }}/>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              Map?: true
@@ -227,9 +257,12 @@ defmodule Surface.PropertiesTest do
     test "passing a keyword list as an expression" do
       assigns = %{submit: [option1: 1, option2: 2]}
 
-      code = """
-      <MapProp prop={{ @submit }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <MapProp prop={{ @submit }}/>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              Map?: true
@@ -239,9 +272,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "validate invalid literals at compile-time" do
-      code = """
-      <MapProp prop="some string"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <MapProp prop="some string"/>
+          """
+        end
 
       message =
         ~S(code:1: invalid value for property "prop". Expected a :map, got: "some string".)
@@ -254,9 +290,12 @@ defmodule Surface.PropertiesTest do
     test "validate invalid values at runtime" do
       assigns = %{var: 1}
 
-      code = """
-      <MapProp prop={{ @var }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <MapProp prop={{ @var }}/>
+          """
+        end
 
       message = """
       invalid value for property "prop". Expected a :map, got: 1.
@@ -272,9 +311,12 @@ defmodule Surface.PropertiesTest do
 
   describe "list" do
     test "passing a list" do
-      code = """
-      <ListProp prop={{ [1, 2] }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ [1, 2] }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              List?: true
@@ -286,9 +328,12 @@ defmodule Surface.PropertiesTest do
     test "passing a list as an expression" do
       assigns = %{submit: [1, 2]}
 
-      code = """
-      <ListProp prop={{ @submit }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ @submit }}/>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              List?: true
@@ -300,9 +345,12 @@ defmodule Surface.PropertiesTest do
     test "passing a list with a single value as an expression" do
       assigns = %{submit: [1]}
 
-      code = """
-      <ListProp prop={{ @submit }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ @submit }}/>
+          """
+        end
 
       assert render_live(code, assigns) =~ """
              List?: true
@@ -311,9 +359,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a list without brackets is invalid" do
-      code = """
-      <ListProp prop={{ 1, 2 }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ 1, 2 }}/>
+          """
+        end
 
       message = ~S(code:1: invalid value for property "prop". Expected a :list, got: {{ 1, 2 }}.)
 
@@ -323,9 +374,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a list with a single value without brackets is invalid" do
-      code = """
-      <ListProp prop={{ 1 }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ 1 }}/>
+          """
+        end
 
       message = "invalid value for property \"prop\". Expected a :list, got: 1"
 
@@ -335,9 +389,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list" do
-      code = """
-      <ListProp prop={{ [a: 1, b: 2] }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ [a: 1, b: 2] }}/>
+          """
+        end
 
       assert render_live(code, %{}) =~ """
              List?: true
@@ -346,9 +403,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list without brackets" do
-      code = """
-      <ListProp prop={{ a: 1, b: 2 }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ a: 1, b: 2 }}/>
+          """
+        end
 
       assert render_live(code, %{}) =~ """
              List?: true
@@ -357,9 +417,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "validate invalid literals at compile-time" do
-      code = """
-      <ListProp prop="some string"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop="some string"/>
+          """
+        end
 
       message =
         ~S(code:1: invalid value for property "prop". Expected a :list, got: "some string".)
@@ -370,9 +433,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "validate invalid values at runtime" do
-      code = """
-      <ListProp prop={{ %{test: 1} }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <ListProp prop={{ %{test: 1} }}/>
+          """
+        end
 
       message = "invalid value for property \"prop\". Expected a :list, got: %{test: 1}"
 
@@ -384,9 +450,12 @@ defmodule Surface.PropertiesTest do
 
   describe "css_class" do
     test "passing a string" do
-      code = """
-      <CSSClassProp prop="class1 class2"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <CSSClassProp prop="class1 class2"/>
+          """
+        end
 
       assert render_live(code) =~ """
              <span class="class1 class2"></span>
@@ -394,9 +463,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keywod list" do
-      code = """
-      <CSSClassProp prop={{ [class1: true, class2: false, class3: "truthy"] }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <CSSClassProp prop={{ [class1: true, class2: false, class3: "truthy"] }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              <span class="class1 class3"></span>
@@ -404,9 +476,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keywod list without brackets" do
-      code = """
-      <CSSClassProp prop={{ class1: true, class2: false, class3: "truthy" }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <CSSClassProp prop={{ class1: true, class2: false, class3: "truthy" }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              <span class="class1 class3"></span>
@@ -414,9 +489,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "trim class items" do
-      code = """
-      <CSSClassProp prop={{ "", " class1 " , "", " ", "  ", " class2 class3 ", "" }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <CSSClassProp prop={{ "", " class1 " , "", " ", "  ", " class2 class3 ", "" }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              <span class="class1 class2 class3"></span>
@@ -424,17 +502,23 @@ defmodule Surface.PropertiesTest do
     end
 
     test "values are always converted to a list of strings" do
-      code = """
-      <CSSClassPropInspect prop="class1 class2   class3"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <CSSClassPropInspect prop="class1 class2   class3"/>
+          """
+        end
 
       assert render_live(code) =~ """
              <div>class1</div><div>class2</div><div>class3</div>
              """
 
-      code = """
-      <CSSClassPropInspect prop={{ ["class1"] ++ ["class2 class3", :class4, class5: true] }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <CSSClassPropInspect prop={{ ["class1"] ++ ["class2 class3", :class4, class5: true] }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              <div>class1</div><div>class2</div><div>class3</div><div>class4</div><div>class5</div>
@@ -444,9 +528,12 @@ defmodule Surface.PropertiesTest do
 
   describe "accumulate" do
     test "if true, groups all props with the same name in a single list" do
-      code = """
-      <AccumulateProp prop="str_1" prop={{ "str_2" }}/>
-      """
+      code =
+        quote do
+          ~H"""
+          <AccumulateProp prop="str_1" prop={{ "str_2" }}/>
+          """
+        end
 
       assert render_live(code) =~ """
              List?: true
@@ -456,9 +543,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "if true and there's a single prop, it stills creates a list" do
-      code = """
-      <AccumulateProp prop="str_1"/>
-      """
+      code =
+        quote do
+          ~H"""
+          <AccumulateProp prop="str_1"/>
+          """
+        end
 
       assert render_live(code) =~ """
              List?: true
@@ -467,9 +557,12 @@ defmodule Surface.PropertiesTest do
     end
 
     test "without any props, takes the default value" do
-      code = """
-      <AccumulateProp/>
-      """
+      code =
+        quote do
+          ~H"""
+          <AccumulateProp/>
+          """
+        end
 
       assert render_live(code) =~ """
              List?: true

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -161,22 +161,25 @@ defmodule Surface.SlotTest do
   end
 
   test "render slot without slot props" do
-    code = """
-    <OuterWithMultipleSlotableEntries>
-      Content 1
-      <InnerData label="label 1">
-        <b>content 1</b>
-        <StatefulComponent id="stateful1"/>
-      </InnerData>
-      Content 2
-        Content 2.1
-      <InnerData label="label 2">
-        <b>content 2</b>
-      </InnerData>
-      Content 3
-      <StatefulComponent id="stateful2"/>
-    </OuterWithMultipleSlotableEntries>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithMultipleSlotableEntries>
+          Content 1
+          <InnerData label="label 1">
+            <b>content 1</b>
+            <StatefulComponent id="stateful1"/>
+          </InnerData>
+          Content 2
+            Content 2.1
+          <InnerData label="label 2">
+            <b>content 2</b>
+          </InnerData>
+          Content 3
+          <StatefulComponent id="stateful2"/>
+        </OuterWithMultipleSlotableEntries>
+        """
+      end
 
     assert_html(
       render_live(code) =~ """
@@ -201,13 +204,16 @@ defmodule Surface.SlotTest do
   end
 
   test "assign named slots with props" do
-    code = """
-    <OuterWithNamedSlotAndProps>
-      <template slot="body" :let={{ info: my_info }}>
-        Info: {{ my_info }}
-      </template>
-    </OuterWithNamedSlotAndProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithNamedSlotAndProps>
+          <template slot="body" :let={{ info: my_info }}>
+            Info: {{ my_info }}
+          </template>
+        </OuterWithNamedSlotAndProps>
+        """
+      end
 
     assert_html(
       render_live(code) =~ """
@@ -219,11 +225,14 @@ defmodule Surface.SlotTest do
   end
 
   test "assign default slot with props" do
-    code = """
-    <OuterWithDefaultSlotAndProps :let={{ info: my_info }}>
-      Info: {{ my_info }}
-    </OuterWithDefaultSlotAndProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithDefaultSlotAndProps :let={{ info: my_info }}>
+          Info: {{ my_info }}
+        </OuterWithDefaultSlotAndProps>
+        """
+      end
 
     assert_html(
       render_live(code) =~ """
@@ -235,11 +244,14 @@ defmodule Surface.SlotTest do
   end
 
   test "assign default slot ignoring all props" do
-    code = """
-    <OuterWithDefaultSlotAndProps>
-      Info
-    </OuterWithDefaultSlotAndProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithDefaultSlotAndProps>
+          Info
+        </OuterWithDefaultSlotAndProps>
+        """
+      end
 
     assert_html(
       render_live(code) =~ """
@@ -251,17 +263,20 @@ defmodule Surface.SlotTest do
   end
 
   test "assign named slots without props" do
-    code = """
-    <OuterWithNamedSlot>
-      <template slot="header">
-        My header
-      </template>
-      My body
-      <template slot="footer">
-        My footer
-      </template>
-    </OuterWithNamedSlot>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithNamedSlot>
+          <template slot="header">
+            My header
+          </template>
+          My body
+          <template slot="footer">
+            My footer
+          </template>
+        </OuterWithNamedSlot>
+        """
+      end
 
     assert_html(
       render_live(code) =~ """
@@ -275,17 +290,20 @@ defmodule Surface.SlotTest do
   end
 
   test "assign undeclared slots without props" do
-    code = """
-    <OuterWithoutDeclaringSlots>
-      <template slot="header">
-        My header
-      </template>
-      My body
-      <template slot="footer">
-        My footer
-      </template>
-    </OuterWithoutDeclaringSlots>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithoutDeclaringSlots>
+          <template slot="header">
+            My header
+          </template>
+          My body
+          <template slot="footer">
+            My footer
+          </template>
+        </OuterWithoutDeclaringSlots>
+        """
+      end
 
     assert_html(
       render_live(code) =~ """
@@ -299,9 +317,12 @@ defmodule Surface.SlotTest do
   end
 
   test "fallback content" do
-    code = """
-    <OuterWithNamedSlot/>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithNamedSlot/>
+        """
+      end
 
     assert_html(
       render_live(code) =~ """
@@ -316,13 +337,16 @@ defmodule Surface.SlotTest do
   test "slotable component with default value for prop" do
     assigns = %{items: [%{id: 1, name: "First"}, %{id: 2, name: "Second"}]}
 
-    code = """
-    <Grid items={{ user <- @items }}>
-      <ColumnWithDefaultTitle>
-        <b>Id: {{ user.id }}</b>
-      </ColumnWithDefaultTitle>
-    </Grid>
-    """
+    code =
+      quote do
+        ~H"""
+        <Grid items={{ user <- @items }}>
+          <ColumnWithDefaultTitle>
+            <b>Id: {{ user.id }}</b>
+          </ColumnWithDefaultTitle>
+        </Grid>
+        """
+      end
 
     assert_html(
       render_live(code, assigns) =~ """
@@ -342,16 +366,19 @@ defmodule Surface.SlotTest do
   test "render slot with slot props containing parent bindings" do
     assigns = %{items: [%{id: 1, name: "First"}, %{id: 2, name: "Second"}]}
 
-    code = """
-    <Grid items={{ user <- @items }}>
-      <Column title="ID">
-        <b>Id: {{ user.id }}</b>
-      </Column>
-      <Column title="NAME">
-        Name: {{ user.name }}
-      </Column>
-    </Grid>
-    """
+    code =
+      quote do
+        ~H"""
+        <Grid items={{ user <- @items }}>
+          <Column title="ID">
+            <b>Id: {{ user.id }}</b>
+          </Column>
+          <Column title="NAME">
+            Name: {{ user.name }}
+          </Column>
+        </Grid>
+        """
+      end
 
     assert_html(
       render_live(code, assigns) =~ """
@@ -373,17 +400,20 @@ defmodule Surface.SlotTest do
   test "render slot renaming slot props" do
     assigns = %{items: [%{id: 1, name: "First"}]}
 
-    code = """
-    <Grid items={{ user <- @items }}>
-      <Column title="ID" :let={{ item: my_user }}>
-        <b>Id: {{ my_user.id }}</b>
-      </Column>
-      <Column title="NAME" :let={{ info: my_info }}>
-        Name: {{ user.name }}
-        Info: {{ my_info }}
-      </Column>
-    </Grid>
-    """
+    code =
+      quote do
+        ~H"""
+        <Grid items={{ user <- @items }}>
+          <Column title="ID" :let={{ item: my_user }}>
+            <b>Id: {{ my_user.id }}</b>
+          </Column>
+          <Column title="NAME" :let={{ info: my_info }}>
+            Name: {{ user.name }}
+            Info: {{ my_info }}
+          </Column>
+        </Grid>
+        """
+      end
 
     assert_html(
       render_live(code, assigns) =~ """
@@ -403,14 +433,17 @@ defmodule Surface.SlotTest do
   test "raise compile error for undefined slot props" do
     assigns = %{items: [%{id: 1, name: "First"}]}
 
-    code = """
-    <Grid items={{ user <- @items }}>
-      <Column title="ID"
-        :let={{ item: my_user, non_existing: value }}>
-        <b>Id: {{ my_user.id }}</b>
-      </Column>
-    </Grid>
-    """
+    code =
+      quote do
+        ~H"""
+        <Grid items={{ user <- @items }}>
+          <Column title="ID"
+            :let={{ item: my_user, non_existing: value }}>
+            <b>Id: {{ my_user.id }}</b>
+          </Column>
+        </Grid>
+        """
+      end
 
     message = """
     code:3: undefined prop `:non_existing` for slot `cols` in `Surface.SlotTest.Grid`.
@@ -429,13 +462,16 @@ defmodule Surface.SlotTest do
   test "raise compile error for invalid :let expression" do
     assigns = %{items: [%{id: 1, name: "First"}]}
 
-    code = """
-    <OuterWithNamedSlotAndProps>
-      <template slot="body"
-        :let={{ "a_string" }}>
-      </template>
-    </OuterWithNamedSlotAndProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithNamedSlotAndProps>
+          <template slot="body"
+            :let={{ "a_string" }}>
+          </template>
+        </OuterWithNamedSlotAndProps>
+        """
+      end
 
     message = """
     code:3: invalid value for directive :let. \
@@ -449,11 +485,14 @@ defmodule Surface.SlotTest do
   end
 
   test "raise compile error when using :let and there's no default slot defined" do
-    code = """
-    <OuterWithoutDefaultSlot :let={{ info: my_info }}>
-      Info: {{ my_info }}
-    </OuterWithoutDefaultSlot>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithoutDefaultSlot :let={{ info: my_info }}>
+          Info: {{ my_info }}
+        </OuterWithoutDefaultSlot>
+        """
+      end
 
     message = """
     code:1: there's no `default` slot defined in `Surface.SlotTest.OuterWithoutDefaultSlot`.
@@ -470,11 +509,14 @@ defmodule Surface.SlotTest do
   end
 
   test "raise compile error when using :let with undefined props for default slot" do
-    code = """
-    <OuterWithDefaultSlotAndProps :let={{ info: my_info, non_existing: value }}>
-      Info: {{ my_info }}
-    </OuterWithDefaultSlotAndProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithDefaultSlotAndProps :let={{ info: my_info, non_existing: value }}>
+          Info: {{ my_info }}
+        </OuterWithDefaultSlotAndProps>
+        """
+      end
 
     message = """
     code:1: undefined prop `:non_existing` for slot `default` in \
@@ -492,13 +534,16 @@ defmodule Surface.SlotTest do
   end
 
   test "raise compile error when using :let with undefined slot props" do
-    code = """
-    <OuterWithNamedSlotAndProps>
-      <template slot="body" :let={{ non_existing: my_info }}>
-        Info: {{ my_info }}
-      </template>
-    </OuterWithNamedSlotAndProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithNamedSlotAndProps>
+          <template slot="body" :let={{ non_existing: my_info }}>
+            Info: {{ my_info }}
+          </template>
+        </OuterWithNamedSlotAndProps>
+        """
+      end
 
     message = """
     code:2: undefined prop `:non_existing` for slot `body` in \
@@ -516,12 +561,15 @@ defmodule Surface.SlotTest do
   end
 
   test "raise compile error when passing invalid bindings to :let " do
-    code = """
-    <OuterWithDefaultSlotAndProps
-      :let={{ info: [my_info] }}>
-      Info: {{ my_info }}
-    </OuterWithDefaultSlotAndProps>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithDefaultSlotAndProps
+          :let={{ info: [my_info] }}>
+          Info: {{ my_info }}
+        </OuterWithDefaultSlotAndProps>
+        """
+      end
 
     message = """
     code:2: invalid value for directive :let. Expected a keyword list of bindings, \
@@ -580,11 +628,14 @@ defmodule Surface.SlotSyncTest do
   alias Surface.SlotTest.StatefulComponent, warn: false
 
   test "warn if parent component does not define any slots" do
-    code = """
-    <StatefulComponent id="stateful">
-      <InnerData/>
-    </StatefulComponent>
-    """
+    code =
+      quote do
+        ~H"""
+        <StatefulComponent id="stateful">
+          <InnerData/>
+        </StatefulComponent>
+        """
+      end
 
     output =
       capture_io(:standard_error, fn ->
@@ -598,12 +649,15 @@ defmodule Surface.SlotSyncTest do
   end
 
   test "warn if parent component does not define the slot" do
-    code = """
-    <Grid items={{[]}}>
-      <InnerData/>
-      <Column title="ID"/>
-    </Grid>
-    """
+    code =
+      quote do
+        ~H"""
+        <Grid items={{[]}}>
+          <InnerData/>
+          <Column title="ID"/>
+        </Grid>
+        """
+      end
 
     output =
       capture_io(:standard_error, fn ->
@@ -619,13 +673,16 @@ defmodule Surface.SlotSyncTest do
   end
 
   test "warn and suggest similar slot if parent component does not define the slot" do
-    code = """
-    <OuterWithNamedSlot>
-      <template slot="foot">
-        My footer
-      </template>
-    </OuterWithNamedSlot>
-    """
+    code =
+      quote do
+        ~H"""
+        <OuterWithNamedSlot>
+          <template slot="foot">
+            My footer
+          </template>
+        </OuterWithNamedSlot>
+        """
+      end
 
     output =
       capture_io(:standard_error, fn ->


### PR DESCRIPTION
This fixes a bunch of issues with `render_live`, including some nasty syntax errors when using certain expressions.

  * Replace `eval_string` with `eval_quoted`
  * Rename the generated dynamic module with the `test module` + `test description` + `line of render_live call` for better error reporting
  * Replace all string based `code` with quoted `~H"""`