### PR TITLE
fix multi element nested tuples

### DIFF
--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -53,12 +53,14 @@ defmodule Surface.Compiler.Parser do
   defparsecp(
     :tuple,
     string("{")
-    |> choice([
-      parsec(:tuple),
-      parsec(:binary),
-      parsec(:charlist),
-      repeat(utf8_char(not: ?}))
-    ])
+    |> repeat(
+      choice([
+        parsec(:tuple),
+        parsec(:binary),
+        parsec(:charlist),
+        utf8_char(not: ?})
+      ])
+    )
     |> string("}")
   )
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -643,17 +643,14 @@ defmodule Surface.Compiler.ParserTest do
       <li :for={{ {a, {b, c}} <- [{"a", {"b", "c"}}]}} />
       """
 
+      attr_value = {:attribute_expr, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]", %{line: 1}}
+
+      attributes = [
+        {":for", attr_value, %{line: 1, spaces: [" ", "", ""]}}
+      ]
+
       assert parse(code) ==
-               {:ok,
-                [
-                  {"li",
-                   [
-                     {":for",
-                      {:attribute_expr, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]", %{line: 1}},
-                      %{line: 1, spaces: [" ", "", ""]}}
-                   ], [], %{line: 1, space: " "}},
-                  "\n"
-                ]}
+               {:ok, [{"li", attributes, [], %{line: 1, space: " "}}, "\n"]}
     end
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -629,5 +629,33 @@ defmodule Surface.Compiler.ParserTest do
 
       assert parse(code) == {:ok, [{"foo", attributes, [], %{line: 1, space: ""}}, "\n"]}
     end
+
+    test "attribute expression with nested tuples" do
+      code = """
+      <ul>
+        <li :for={{ {a, {b, c}} <- [{"a", {"b", "c"}}]}}>
+          {{ c }}
+        </li>
+      </ul>
+      """
+
+      assert parse(code) ==
+               {:ok,
+                [
+                  {"ul", [],
+                   [
+                     "\n  ",
+                     {"li",
+                      [
+                        {":for",
+                         {:attribute_expr, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]",
+                          %{line: 2}}, %{line: 2, spaces: [" ", "", ""]}}
+                      ], ["\n    ", {:interpolation, " c ", %{line: 3}}, "\n  "],
+                      %{line: 2, space: ""}},
+                     "\n"
+                   ], %{line: 1, space: ""}},
+                  "\n"
+                ]}
+    end
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -285,6 +285,14 @@ defmodule Surface.Compiler.ParserTest do
       assert parse("{{ \"a\\\"b\" }}") ==
                {:ok, [{:interpolation, " \"a\\\"b\" ", %{line: 1}}]}
     end
+
+    test "nested multi-element tuples" do
+      assert parse("""
+             {{ {a, {b, c}} <- [{"a", {"b", "c"}}]}}
+             """) ==
+               {:ok,
+                [{:interpolation, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]", %{line: 1}}, "\n"]}
+    end
   end
 
   describe "with macros" do
@@ -632,28 +640,18 @@ defmodule Surface.Compiler.ParserTest do
 
     test "attribute expression with nested tuples" do
       code = """
-      <ul>
-        <li :for={{ {a, {b, c}} <- [{"a", {"b", "c"}}]}}>
-          {{ c }}
-        </li>
-      </ul>
+      <li :for={{ {a, {b, c}} <- [{"a", {"b", "c"}}]}} />
       """
 
       assert parse(code) ==
                {:ok,
                 [
-                  {"ul", [],
+                  {"li",
                    [
-                     "\n  ",
-                     {"li",
-                      [
-                        {":for",
-                         {:attribute_expr, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]",
-                          %{line: 2}}, %{line: 2, spaces: [" ", "", ""]}}
-                      ], ["\n    ", {:interpolation, " c ", %{line: 3}}, "\n  "],
-                      %{line: 2, space: ""}},
-                     "\n"
-                   ], %{line: 1, space: ""}},
+                     {":for",
+                      {:attribute_expr, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]", %{line: 1}},
+                      %{line: 1, spaces: [" ", "", ""]}}
+                   ], [], %{line: 1, space: " "}},
                   "\n"
                 ]}
     end


### PR DESCRIPTION
The parser was missing a repeat which broke multi-element tuples (i.e. `{a, {b, c}}`) in interpolation and expressions

resolves #185