### PR TITLE
Move constructs to its own namespace

### DIFF
--- a/lib/surface/component.ex
+++ b/lib/surface/component.ex
@@ -42,6 +42,7 @@ defmodule Surface.Component do
 
       @before_compile unquote(__MODULE__)
 
+      alias Surface.Constructs.{For, If}
       alias Surface.Components.Context
 
       if unquote(slot_name) != nil do

--- a/lib/surface/constructs/for.ex
+++ b/lib/surface/constructs/for.ex
@@ -1,12 +1,12 @@
-defmodule Surface.Components.If do
+defmodule Surface.Constructs.For do
   @moduledoc """
-  Provides an alternative to the `:if` directive for wrapping multiple elements in an if expression.
+  Provides an alternative to the `:for` directive for wrapping multiple elements in a for loop.
 
   ## Examples
   ```
-  <If condition={{ @display_link }} />
+  <For each={{ item <- @items }} />
+    <a href={{ item.to }}>{{item.label}}</a>
     <Icon name="cheveron_left" />
-    <a href={{ @item.to }}>{{ @item.label }}</a>
   </For>
   ```
   """
@@ -14,19 +14,19 @@ defmodule Surface.Components.If do
 
   alias Surface.AST
 
-  @doc "The condition for the if expression"
-  prop condition, :boolean, required: true
+  @doc "The generator for the for expression"
+  prop each, :generator, required: true
   slot default, required: true
 
   def render(_), do: ""
 
   def transform(node) do
-    condition =
+    generator =
       Enum.find_value(
         node.props,
-        %AST.AttributeExpr{value: false, original: "", meta: node.meta},
+        %AST.AttributeExpr{value: [], original: "", meta: node.meta},
         fn prop ->
-          if prop.name == :condition do
+          if prop.name == :each do
             prop.value
           end
         end
@@ -37,8 +37,8 @@ defmodule Surface.Components.If do
         do: [],
         else: List.first(node.templates.default).children
 
-    %AST.If{
-      condition: condition,
+    %AST.For{
+      generator: generator,
       children: children,
       meta: node.meta
     }

--- a/lib/surface/constructs/if.ex
+++ b/lib/surface/constructs/if.ex
@@ -1,12 +1,12 @@
-defmodule Surface.Components.For do
+defmodule Surface.Constructs.If do
   @moduledoc """
-  Provides an alternative to the `:for` directive for wrapping multiple elements in a for loop.
+  Provides an alternative to the `:if` directive for wrapping multiple elements in an if expression.
 
   ## Examples
   ```
-  <For each={{ item <- @items }} />
-    <a href={{ item.to }}>{{item.label}}</a>
+  <If condition={{ @display_link }} />
     <Icon name="cheveron_left" />
+    <a href={{ @item.to }}>{{ @item.label }}</a>
   </For>
   ```
   """
@@ -14,19 +14,19 @@ defmodule Surface.Components.For do
 
   alias Surface.AST
 
-  @doc "The generator for the for expression"
-  prop each, :generator, required: true
+  @doc "The condition for the if expression"
+  prop condition, :boolean, required: true
   slot default, required: true
 
   def render(_), do: ""
 
   def transform(node) do
-    generator =
+    condition =
       Enum.find_value(
         node.props,
-        %AST.AttributeExpr{value: [], original: "", meta: node.meta},
+        %AST.AttributeExpr{value: false, original: "", meta: node.meta},
         fn prop ->
-          if prop.name == :each do
+          if prop.name == :condition do
             prop.value
           end
         end
@@ -37,8 +37,8 @@ defmodule Surface.Components.For do
         do: [],
         else: List.first(node.templates.default).children
 
-    %AST.For{
-      generator: generator,
+    %AST.If{
+      condition: condition,
       children: children,
       meta: node.meta
     }

--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -62,6 +62,7 @@ defmodule Surface.LiveComponent do
       use Surface.API, include: [:prop, :slot, :data]
       import Phoenix.HTML
 
+      alias Surface.Constructs.{For, If}
       alias Surface.Components.Context
 
       @doc """

--- a/lib/surface/live_view.ex
+++ b/lib/surface/live_view.ex
@@ -37,6 +37,9 @@ defmodule Surface.LiveView do
       use Surface.API, include: [:prop, :data]
       import Phoenix.HTML
 
+      alias Surface.Constructs.{For, If}
+      alias Surface.Components.Context
+
       @before_compile Surface.Renderer
       @before_compile unquote(__MODULE__)
 

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -1,8 +1,6 @@
 defmodule Surface.Components.ForTest do
   use ExUnit.Case, async: true
 
-  alias Surface.Components.For, warn: false
-
   import ComponentTestHelper
 
   defmodule ListProp do

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -1,4 +1,4 @@
-defmodule Surface.Components.ForTest do
+defmodule Surface.Constructs.ForTest do
   use ExUnit.Case, async: true
 
   import ComponentTestHelper

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -1,4 +1,4 @@
-defmodule Surface.Components.IfTest do
+defmodule Surface.Constructs.IfTest do
   use ExUnit.Case, async: true
 
   import ComponentTestHelper

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -1,8 +1,6 @@
 defmodule Surface.Components.IfTest do
   use ExUnit.Case, async: true
 
-  alias Surface.Components.If, warn: false
-
   import ComponentTestHelper
 
   defmodule ListProp do


### PR DESCRIPTION
  * Move For and If to Surface.Constructs namespace
  * Create aliases to For and If

@lnr0626 I gave up moving `Context` too. The implementation is quite different and depends on code in the compiler/eex_engine so I left it out for now.