### PR TITLE
Fix line for string with interpolation

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -474,6 +474,7 @@ defmodule Surface.Compiler do
     {originals, quoted_values} =
       Enum.reduce(values, {[], []}, fn
         {:attribute_expr, value, expr_meta}, {originals, quoted_values} ->
+          expr_meta = Helpers.to_meta(expr_meta, attr_meta)
           {["{{#{value}}}" | originals], [quote_embedded_expr(value, expr_meta) | quoted_values]}
 
         value, {originals, quoted_values} ->

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -134,7 +134,7 @@ defmodule Surface.PropertiesTest do
         end)
 
       assert output =~ ~r/variable "func" does not exist/
-      assert output =~ ~r"  code.exs:7:"
+      assert output =~ ~r"  code.exs:7"
     end
   end
 

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -3,6 +3,7 @@ defmodule Surface.PropertiesTest do
 
   import Surface
   import ComponentTestHelper
+  import ExUnit.CaptureIO
 
   defmodule StringProp do
     use Surface.Component
@@ -102,6 +103,38 @@ defmodule Surface.PropertiesTest do
         end
 
       assert render_live(code, %{a: 1, b: "two"}) =~ "begin 1 two end"
+    end
+
+    test "raise error on the right line for string with interpolation" do
+      id = :erlang.unique_integer([:positive]) |> to_string()
+      module = "Surface.PropertiesTest_#{id}"
+
+      code = """
+      defmodule #{module} do
+        use Elixir.Surface.Component
+
+        def render(assigns) do
+          ~H"\""
+          <StringProp
+            label="Undefined func {{ func }}"
+          />
+          "\""
+        end
+      end
+      """
+
+      error_message = "code.exs:7: undefined function func/0"
+
+      output =
+        capture_io(:standard_error, fn ->
+          assert_raise(CompileError, error_message, fn ->
+            {{:module, _, _, _}, _} =
+              Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
+          end)
+        end)
+
+      assert output =~ ~r/variable "func" does not exist/
+      assert output =~ ~r"  code.exs:7:"
     end
   end
 


### PR DESCRIPTION
Errors on properties using string interpolation were pointing to the wrong line.

This PR fixes the issue and adds a proper test.

@lnr0626 before fixing the problem I added following test:

```elixir
test "raise error on the right line for string with interpolation" do
  code =
    quote do
        ~H"""
        <div>
        <StringProp
          label="Undefined func {{ func }}"
        />
        </div>
        """
    end
    
  assert_raise(CompileError, "code:3: undefined function func/0", fn ->
    render_live(code, %{})
  end)
end
```

Which didn't catch the error. It passed flawlessly. 

The test is misleading as it reports the line having the `~H"""` as the offset, which is ok for all cases where the metadata was properly initialized with `Helpers.to_meta`. However, if the metadata is not initialized like that, the tests will never fail. 

I believe we have most of our tests using ` render_live` like this so none of them will ever catch a similar bug.

It's the second time recently we have a similar bug due to a missing `Helpers.to_meta`. We need to either change `render_live` to report the error taking the beginning of the file as offset or somehow raise an error if the metadata has not been initialized. The former is easier to implement but it will make the tests look weird as we'll have to assert on a line that does not correspond the line we see in the test.

Let me know if you have any other idea.