### PR TITLE
default_class config option for <ErrorTag>

### DIFF
--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -61,7 +61,19 @@ defmodule Surface.Components.Form.ErrorTag do
   @doc "An identifier for the associated field"
   prop field, :atom
 
-  @doc "Class or classes to apply to each error tag <span>"
+  @doc """
+  Classes to apply to each error tag <span>.
+
+  This can also be set via config, for example:
+
+  ```elixir
+  config :surface, :components, [
+    {Surface.Components.Form.ErrorTag, default_class: "invalid-feedback"}
+  ]
+  ```
+
+  However, the prop overrides the config value if provided.
+  """
   prop class, :css_class
 
   @doc """
@@ -89,12 +101,13 @@ defmodule Surface.Components.Form.ErrorTag do
 
   def render(assigns) do
     translate_error = assigns.translator || translator_from_config() || (&translate_error/1)
+    class = assigns.class || get_config(:default_class)
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
       <span
         :for={{ error <- Keyword.get_values(form.errors, field) }}
-        class={{ @class }}
+        class={{ class }}
         phx-feedback-for={{ @phx_feedback_for || input_id(form, field) }}
       >{{ translate_error.(error) }}</span>
     </InputContext>

--- a/test/components/form/error_tag_test.exs
+++ b/test/components/form/error_tag_test.exs
@@ -180,6 +180,46 @@ defmodule Surface.Components.Form.ErrorTagSyncTest do
     end
   end
 
+  test "default_class from config", %{changeset: changeset} do
+    using_config ErrorTag, default_class: "class-from-config" do
+      assigns = %{changeset: changeset}
+
+      code =
+        quote do
+          ~H"""
+          <Form for={{@changeset}} opts={{ as: :user }}>
+            <Field name="name">
+              <ErrorTag />
+            </Field>
+          </Form>
+          """
+        end
+
+      assert render_live(code, assigns) =~
+               "<span class=\"class-from-config\" phx-feedback-for=\"user_name\">is already taken</span>"
+    end
+  end
+
+  test "prop class overrides config", %{changeset: changeset} do
+    using_config ErrorTag, default_class: "class-from-config" do
+      assigns = %{changeset: changeset}
+
+      code =
+        quote do
+          ~H"""
+          <Form for={{@changeset}} opts={{ as: :user }}>
+            <Field name="name">
+              <ErrorTag class="class-from-prop" />
+            </Field>
+          </Form>
+          """
+        end
+
+      assert render_live(code, assigns) =~
+               "<span class=\"class-from-prop\" phx-feedback-for=\"user_name\">is already taken</span>"
+    end
+  end
+
   def config_translate_error({_msg, _opts}) do
     "translated by config translator"
   end


### PR DESCRIPTION
Adds the ability to do this:

```elixir
config :surface, :components, [
  {Surface.Components.Form.ErrorTag, default_class: "invalid-feedback"}
]
```

As a result, all `<ErrorTag>` components render:

```html
<span class="invalid-feedback" ...>
```

---

The `class` prop overrides it.

```surface
<ErrorTag class="overriding" />
```

```html
<span class="overriding" ...>
```