### PR TITLE
Added props to Form input elements, fixes #200 

### DIFF
--- a/lib/surface/components/form.ex
+++ b/lib/surface/components/form.ex
@@ -22,7 +22,25 @@ defmodule Surface.Components.Form do
   @doc "URL to where the form is submitted"
   prop action, :string, default: "#"
 
-  @doc "Keyword list with options to be passed down to `form_for/3`"
+  @doc "The server side parameter in which all parameters will be gathered."
+  prop as, :atom
+
+  @doc "Method to be used when submitting the form, default \"post\"."
+  prop method, :string, default: "post"
+
+  @doc "When true, sets enctype to \"multipart/form-data\". Required when uploading files."
+  prop multipart, :boolean, default: false
+
+  @doc """
+  For \"post\" requests, the form tag will automatically include an input
+  tag with name _csrf_token. When set to false, this is disabled.
+  """
+  prop csrf_token, :any
+
+  @doc "Keyword list of errors for the form."
+  prop errors, :keyword
+
+  @doc "Keyword list with options to be passed down to `Phoenix.HTML.Tag.tag/2``"
   prop opts, :keyword, default: []
 
   @doc "Triggered when the form is changed"
@@ -45,7 +63,15 @@ defmodule Surface.Components.Form do
   end
 
   defp get_opts(assigns) do
-    assigns.opts ++
+    form_opts =
+      ~w/as method multipart csrf_token errors/a
+      |> Enum.reduce([], fn key, acc ->
+        value = Map.get(assigns, key)
+        (is_nil(value) && acc) || Keyword.put(acc, key, value)
+      end)
+
+    form_opts ++
+      assigns.opts ++
       event_to_opts(assigns.change, :phx_change) ++
       event_to_opts(assigns.submit, :phx_submit)
   end

--- a/lib/surface/components/form.ex
+++ b/lib/surface/components/form.ex
@@ -14,6 +14,7 @@ defmodule Surface.Components.Form do
   use Surface.Component
 
   import Phoenix.HTML.Form
+  import Surface.Components.Form.Utils, only: [get_non_nil_props: 2]
   alias Surface.Components.Raw
 
   @doc "Atom or changeset to inform the form data"
@@ -63,12 +64,7 @@ defmodule Surface.Components.Form do
   end
 
   defp get_opts(assigns) do
-    form_opts =
-      ~w/as method multipart csrf_token errors/a
-      |> Enum.reduce([], fn key, acc ->
-        value = Map.get(assigns, key)
-        (is_nil(value) && acc) || Keyword.put(acc, key, value)
-      end)
+    form_opts = get_non_nil_props(assigns, [:as, :method, :multipart, :csrf_token, :errors])
 
     form_opts ++
       assigns.opts ++

--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -20,13 +20,30 @@ defmodule Surface.Components.Form.Checkbox do
   import Phoenix.HTML.Form, only: [checkbox: 3]
   import Surface.Components.Form.Utils
 
+  @doc "The value to be sent when the checkbox is checked. Defaults to \"true\""
+  prop checked_value, :any, default: true
+
+  @doc "Controls if this function will generate a hidden input to submit the unchecked value or not, defaults to \"true\"."
+  prop hidden_input, :boolean, default: true
+
+  @doc "The value to be sent when the checkbox is unchecked, defaults to \"false\"."
+  prop unchecked_value, :any, default: false
+
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:checked, class: get_config(:default_class)])
+    props =
+      get_non_nil_props(assigns, [
+        :checked_value,
+        :hidden_input,
+        :unchecked_value,
+        :checked,
+        class: get_config(:default_class)
+      ])
+
     event_opts = get_events_to_opts(assigns)
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
-      {{ checkbox(form, field, props ++ @opts ++ event_opts) }}
+    {{ checkbox(form, field, props ++ @opts ++ event_opts) }}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -35,7 +35,7 @@ defmodule Surface.Components.Form.Checkbox do
         :checked_value,
         :hidden_input,
         :unchecked_value,
-        :checked,
+        :value,
         class: get_config(:default_class)
       ])
 

--- a/lib/surface/components/form/multiple_select.ex
+++ b/lib/surface/components/form/multiple_select.ex
@@ -26,11 +26,14 @@ defmodule Surface.Components.Form.MultipleSelect do
   @doc "The options in the select"
   prop options, :any, default: []
 
+  @doc "The default selected option"
+  prop selected, :any
+
   @doc "Options list"
   prop opts, :keyword, default: []
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, class: get_config(:default_class))
+    props = get_non_nil_props(assigns, [:selected, class: get_config(:default_class)])
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>

--- a/lib/surface/components/form/select.ex
+++ b/lib/surface/components/form/select.ex
@@ -26,15 +26,18 @@ defmodule Surface.Components.Form.Select do
   @doc "The options in the select"
   prop options, :any, default: []
 
-  @doc "Options list"
-  prop opts, :keyword, default: []
+  @doc "An option to include at the top of the options with the given prompt text"
+  prop prompt, :string
+
+  @doc "The default value to use when none was sent as parameter"
+  prop selected, :any
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, class: get_config(:default_class))
+    props = get_non_nil_props(assigns, [:prompt, :selected, class: get_config(:default_class)])
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
-      {{ select(form, field, @options, props ++ @opts) }}
+      {{ select(form, field, @options, props) }}
     </InputContext>
     """
   end

--- a/test/components/form/checkbox_test.exs
+++ b/test/components/form/checkbox_test.exs
@@ -23,7 +23,7 @@ defmodule Surface.Components.Form.CheckboxTest do
     code =
       quote do
         ~H"""
-        <Form for={{ :user }} opts={{ csrf_token: "test" }}>
+        <Form for={{ :user }} csrf_token="test">
           <Checkbox field={{ :admin }} />
         </Form>
         """
@@ -64,7 +64,7 @@ defmodule Surface.Components.Form.CheckboxTest do
     code =
       quote do
         ~H"""
-        <Checkbox form="user" field="admin" opts={{ checked_value: "admin" }} />
+        <Checkbox form="user" field="admin" checked_value="admin"/>
         """
       end
 

--- a/test/components/form/checkbox_test.exs
+++ b/test/components/form/checkbox_test.exs
@@ -73,6 +73,26 @@ defmodule Surface.Components.Form.CheckboxTest do
            """
   end
 
+  test "setting the value" do
+    code =
+      quote do
+        ~H"""
+        <Checkbox value={{ true }}/>
+        """
+      end
+
+    assert render_live(code) =~ ~r/checked/
+
+    code =
+      quote do
+        ~H"""
+        <Checkbox value={{ false }}/>
+        """
+      end
+
+    refute render_live(code) =~ ~r/checked/
+  end
+
   test "blur event with parent live view as target" do
     code =
       quote do

--- a/test/components/form/file_input_test.exs
+++ b/test/components/form/file_input_test.exs
@@ -22,7 +22,7 @@ defmodule Surface.Components.Form.FileInputTest do
     code =
       quote do
         ~H"""
-        <Form for={{ :user }} opts={{ csrf_token: "test", multipart: true }}>
+        <Form for={{ :user }} csrf_token="test" multipart={{true}} >
           <FileInput field={{ :picture }} />
         </Form>
         """

--- a/test/components/form/multiple_select_test.exs
+++ b/test/components/form/multiple_select_test.exs
@@ -60,7 +60,7 @@ defmodule Surface.Components.Form.MultipleSelectTest do
     code =
       quote do
         ~H"""
-        <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} opts={{ selected: ["admin"] }} />
+        <MultipleSelect form="user" field="roles" options={{ ["Admin": "admin", "User": "user"] }} selected="admin"/>
         """
       end
 

--- a/test/components/form/select_test.exs
+++ b/test/components/form/select_test.exs
@@ -60,7 +60,7 @@ defmodule Surface.Components.Form.SelectTest do
     code =
       quote do
         ~H"""
-        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} opts={{ prompt: "Pick a role" }} />
+        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} prompt="Pick a role"/>
         """
       end
 

--- a/test/components/form_test.exs
+++ b/test/components/form_test.exs
@@ -13,7 +13,7 @@ defmodule Surface.Components.FormTest do
 
     def render(assigns) do
       ~H"""
-      <Form for={{ @changeset }} action="#" opts={{ csrf_token: "test", as: :user }} :let={{ form: f }}>
+      <Form for={{ @changeset }} action="#" csrf_token="test" as={{ :user }} :let={{ form: f }}>
         <TextInput field="name" />
         {{ Enum.map(Keyword.get_values(f.source.errors, :name), fn {msg, _opts} -> ["Name ", msg] end) }}
       </Form>
@@ -29,7 +29,7 @@ defmodule Surface.Components.FormTest do
     code =
       quote do
         ~H"""
-        <Form for={{:user}} action="#" opts={{ csrf_token: "test" }}>
+        <Form for={{:user}} action="#" csrf_token="test">
         </Form>
         """
       end
@@ -43,7 +43,25 @@ defmodule Surface.Components.FormTest do
     code =
       quote do
         ~H"""
-        <Form for={{:user}} action="#" opts={{ csrf_token: "test" }}>
+        <Form for={{:user}} action="#" csrf_token="test">
+          <TextInput field="name" />
+        </Form>
+        """
+      end
+
+    assert render_live(code) =~ """
+           <form action="#" method="post">\
+           <input name="_csrf_token" type="hidden" value="test"/>\
+           <input id="user_name" name="user[name]" type="text"/>\
+           </form>
+           """
+  end
+
+  test "form with form_for/4 opts as props" do
+    code =
+      quote do
+        ~H"""
+        <Form for={{:user}} action="#" csrf_token="test">
           <TextInput field="name" />
         </Form>
         """


### PR DESCRIPTION
I added all the explicit props to the Form input elements, as requested in #200 . 
The only missing prop is the `value` for the checkbox, this was a bit hard to test to get working. Any input is helpful.