### PR TITLE
Fix doc in the ErrorTag component

### DIFF
--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -17,7 +17,7 @@ defmodule Surface.Components.Form.ErrorTag do
 
   ```elixir
   config :surface, :components, [
-    {Surface.Components.Form.ErrorTag, translator: {MyAppWeb.ErrorHelpers, :translate_error}}
+    {Surface.Components.Form.ErrorTag, default_translator: {MyAppWeb.ErrorHelpers, :translate_error}}
   ]
   ```
 
@@ -85,7 +85,7 @@ defmodule Surface.Components.Form.ErrorTag do
 
   ```elixir
   config :surface, :components, [
-    {Surface.Components.Form.ErrorTag, translator: {MyApp.Gettext, :translate_error}}
+    {Surface.Components.Form.ErrorTag, default_translator: {MyApp.Gettext, :translate_error}}
   ]
   ```
   """


### PR DESCRIPTION
This Pull Request fixes an typo in the doc of the ErrorTag component.