### PR TITLE
Add DateSelectComponent

### DIFF
--- a/lib/surface/components/form/date_select.ex
+++ b/lib/surface/components/form/date_select.ex
@@ -1,0 +1,95 @@
+defmodule Surface.Components.Form.DateSelect do
+  @moduledoc """
+  Generates select tags for date.
+
+  Provides a wrapper for Phoenix.HTML.Form's `date_select/3` function.
+
+  All options passed via `opts` will be sent to `date_select/3`, `value`
+  can be set directly and will override anything in `opts`.
+
+
+  ## Examples
+
+  ```
+  <DateSelect form="user" field="born_at" />
+
+  <Form for={{ :user }}>
+    <DateSelect field={{ :born_at }} />
+  </Form>
+  ```
+  """
+
+  use Surface.Component
+
+  import Phoenix.HTML.Form, only: [date_select: 3]
+  import Surface.Components.Form.Utils
+
+  alias Surface.Components.Form.Input.InputContext
+
+  @doc "The form identifier"
+  prop form, :form
+
+  @doc "The field name"
+  prop field, :string
+
+  @doc "Value to pre-populate the select"
+  prop value, :any
+
+  @doc "Default value to use when none was given in 'value' and none is available in the form data"
+  prop default, :any
+
+  @doc "Options passed to the underlying 'year' select"
+  prop year, :keyword
+
+  @doc "Options passed to the underlying 'month' select"
+  prop month, :keyword
+
+  @doc "Options passed to the underlying 'day' select"
+  prop day, :keyword
+
+  @doc """
+  Specify how the select can be build. It must be a function that receives a builder
+  that should be invoked with the select name and a set of options.
+  """
+  prop builder, :fun
+
+  @doc "Options list"
+  prop opts, :keyword, default: []
+
+  def render(assigns) do
+    props =
+      get_non_nil_props(assigns, [
+        :value,
+        :default,
+        :year,
+        :month,
+        :day,
+        :builder
+      ])
+
+    props =
+      props
+      |> parse_css_class_for(:year)
+      |> parse_css_class_for(:month)
+      |> parse_css_class_for(:day)
+
+    ~H"""
+    <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
+      {{ date_select(form, field, props) }}
+    </InputContext>
+    """
+  end
+
+  defp parse_css_class_for(props, field) do
+    class = props[field][:class]
+
+    if class do
+      put_in(props, [field, :class], do_parse_class(class))
+    else
+      props
+    end
+  end
+
+  defp do_parse_class(class) when is_list(class), do: Surface.css_class(class)
+  defp do_parse_class(class), do: class
+end

--- a/test/components/form/date_select_test.exs
+++ b/test/components/form/date_select_test.exs
@@ -1,0 +1,175 @@
+defmodule Surface.Components.Form.DateSelectTest do
+  use ExUnit.Case, async: true
+
+  import ComponentTestHelper
+  alias Surface.Components.Form, warn: false
+  alias Surface.Components.Form.DateSelect, warn: false
+
+  test "datetime select" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect form="user" field="born_at" />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<select id="user_born_at_year" name="user[born_at][year]">)
+    assert content =~ ~s(<select id="user_born_at_month" name="user[born_at][month]">)
+    assert content =~ ~s(<select id="user_born_at_day" name="user[born_at][day]">)
+  end
+
+  test "with form context" do
+    code =
+      quote do
+        ~H"""
+        <Form for={{ :user }}>
+          <DateSelect field={{ :born_at }} />
+        </Form>
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<form action="#" method="post">)
+    assert content =~ ~s(<select id="user_born_at_year" name="user[born_at][year]">)
+    assert content =~ ~s(<select id="user_born_at_month" name="user[born_at][month]">)
+    assert content =~ ~s(<select id="user_born_at_day" name="user[born_at][day]">)
+  end
+
+  test "setting the value as map" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9} }} />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+  end
+
+  test "setting the value as tuple" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect form="user" field="born_at" value={{ {2020, 10, 9} }} />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+  end
+
+  test "setting the default value as map" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect form="user" field="born_at" default={{ %{year: 2020, month: 10, day: 9} }} />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+  end
+
+  test "setting the default value as tuple" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect form="user" field="born_at" default={{ {2020, 10, 9} }} />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+  end
+
+  test "passing options to year, month and day" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect
+          form="user"
+          field="born_at"
+          year={{ prompt: "Year" }}
+          month={{ prompt: "Month" }}
+          day={{ prompt: "Day" }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="">Year</option>)
+    assert content =~ ~s(<option value="">Month</option>)
+    assert content =~ ~s(<option value="">Day</option>)
+  end
+
+  test "passing builder to select" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect
+          form="user"
+          field="born_at"
+          builder={{ fn b ->
+            html_escape([
+              "Year: ",
+              b.(:year, class: "year"),
+              "Month: ",
+              b.(:month, class: "month"),
+              "Day: ",
+              b.(:day, class: "day"),
+            ])
+          end }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(Year: <select class="year" id="user_born_at_year")
+    assert content =~ ~s(Month: <select class="month" id="user_born_at_month")
+    assert content =~ ~s(Day: <select class="day" id="user_born_at_day")
+  end
+
+  test "parsing class option in year, month and day" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect
+          form="user"
+          field="born_at"
+          year={{ class: ["true-class": true, "false-class": false] }}
+          month={{ class: ["true-class": true, "false-class": false] }}
+          day={{ class: "day-class" }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_year" name="user[born_at][year]">)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_month" name="user[born_at][month]">)
+
+    assert content =~
+             ~s(<select class="day-class" id="user_born_at_day" name="user[born_at][day]">)
+  end
+end


### PR DESCRIPTION
This PR aims to add a `DateSelectComponent` that is a wrapper for Phoenix.HTML.Form's `date_select/3` function

- [x] Create component
- [x] Test
- [x] Doc
- [x] Parse "class" option of each select to allow the use of `"my-class": true` format
- [ ] ~Maybe update other select component to respect the new standard way to write Surface Form component.~