### PR TITLE
Standardize datetime select, date select and time select components

### DIFF
--- a/lib/surface/components/form/date_select.ex
+++ b/lib/surface/components/form/date_select.ex
@@ -4,9 +4,9 @@ defmodule Surface.Components.Form.DateSelect do
 
   Provides a wrapper for Phoenix.HTML.Form's `date_select/3` function.
 
-  All options passed via `opts` will be sent to `date_select/3`, `value`
+  All options passed via `opts` will be sent to `date_select/3`,
+  `value`, `default`, `year`, `month`, `day` and `builder`
   can be set directly and will override anything in `opts`.
-
 
   ## Examples
 
@@ -75,21 +75,8 @@ defmodule Surface.Components.Form.DateSelect do
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
-      {{ date_select(form, field, props) }}
+      {{ date_select(form, field, props ++ @opts) }}
     </InputContext>
     """
   end
-
-  defp parse_css_class_for(props, field) do
-    class = props[field][:class]
-
-    if class do
-      put_in(props, [field, :class], do_parse_class(class))
-    else
-      props
-    end
-  end
-
-  defp do_parse_class(class) when is_list(class), do: Surface.css_class(class)
-  defp do_parse_class(class), do: class
 end

--- a/lib/surface/components/form/datetime_select.ex
+++ b/lib/surface/components/form/datetime_select.ex
@@ -4,9 +4,9 @@ defmodule Surface.Components.Form.DateTimeSelect do
 
   Provides a wrapper for Phoenix.HTML.Form's `datetime_select/3` function.
 
-  All options passed via `opts` will be sent to `datetime_select/3`, `value`
+  All options passed via `opts` will be sent to `datetime_select/3`,
+  `value`, `default`, `year`, `month`, `day`, `hour`, `minute`, `second` and `builder`
   can be set directly and will override anything in `opts`.
-
 
   ## Examples
 
@@ -34,11 +34,58 @@ defmodule Surface.Components.Form.DateTimeSelect do
   @doc "Value to pre-populate the select"
   prop value, :any
 
+  @doc "Default value to use when none was given in 'value' and none is available in the form data"
+  prop default, :any
+
+  @doc "Options passed to the underlying 'year' select"
+  prop year, :keyword
+
+  @doc "Options passed to the underlying 'month' select"
+  prop month, :keyword
+
+  @doc "Options passed to the underlying 'day' select"
+  prop day, :keyword
+
+  @doc "Options passed to the underlying 'day' select"
+  prop hour, :keyword
+
+  @doc "Options passed to the underlying 'day' select"
+  prop minute, :keyword
+
+  @doc "Options passed to the underlying 'day' select"
+  prop second, :keyword
+
+  @doc """
+  Specify how the select can be build. It must be a function that receives a builder
+  that should be invoked with the select name and a set of options.
+  """
+  prop builder, :fun
+
   @doc "Options list"
   prop opts, :keyword, default: []
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value])
+    props =
+      get_non_nil_props(assigns, [
+        :value,
+        :default,
+        :year,
+        :month,
+        :day,
+        :hour,
+        :minute,
+        :second,
+        :builder
+      ])
+
+    props =
+      props
+      |> parse_css_class_for(:year)
+      |> parse_css_class_for(:month)
+      |> parse_css_class_for(:day)
+      |> parse_css_class_for(:hour)
+      |> parse_css_class_for(:minute)
+      |> parse_css_class_for(:second)
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>

--- a/lib/surface/components/form/time_select.ex
+++ b/lib/surface/components/form/time_select.ex
@@ -4,9 +4,9 @@ defmodule Surface.Components.Form.TimeSelect do
 
   Provides a wrapper for Phoenix.HTML.Form's `time_select/3` function.
 
-  All options passed via `opts` will be sent to `time_select/3`, `value` can be
-  set directly and will override anything in `opts`.
-
+  All options passed via `opts` will be sent to `time_select/3`,
+  `value`, `default`, `hour`, `minute`, `second` and `builder`
+  can be set directly and will override anything in `opts`.
 
   ## Examples
 
@@ -34,11 +34,43 @@ defmodule Surface.Components.Form.TimeSelect do
   @doc "Value to pre-populate the select"
   prop value, :any
 
+  @doc "Default value to use when none was given in 'value' and none is available in the form data"
+  prop default, :any
+
+  @doc "Options passed to the underlying 'day' select"
+  prop hour, :keyword
+
+  @doc "Options passed to the underlying 'day' select"
+  prop minute, :keyword
+
+  @doc "Options passed to the underlying 'day' select"
+  prop second, :keyword
+
+  @doc """
+  Specify how the select can be build. It must be a function that receives a builder
+  that should be invoked with the select name and a set of options.
+  """
+  prop builder, :fun
+
   @doc "Options list"
   prop opts, :keyword, default: []
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value])
+    props =
+      get_non_nil_props(assigns, [
+        :value,
+        :default,
+        :hour,
+        :minute,
+        :second,
+        :builder
+      ])
+
+    props =
+      props
+      |> parse_css_class_for(:hour)
+      |> parse_css_class_for(:minute)
+      |> parse_css_class_for(:second)
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>

--- a/lib/surface/components/form/utils.ex
+++ b/lib/surface/components/form/utils.ex
@@ -33,4 +33,15 @@ defmodule Surface.Components.Form.Utils do
   def prop_value(assigns, prop) do
     {prop, assigns[prop]}
   end
+
+  @doc false
+  def parse_css_class_for(props, field) do
+    parse_css_class_for(props, field, props[field][:class])
+  end
+
+  defp parse_css_class_for(props, field, class) when is_list(class) do
+    put_in(props, [field, :class], Surface.css_class(class))
+  end
+
+  defp parse_css_class_for(props, _field, _class), do: props
 end

--- a/test/components/form/date_select_test.exs
+++ b/test/components/form/date_select_test.exs
@@ -172,4 +172,28 @@ defmodule Surface.Components.Form.DateSelectTest do
     assert content =~
              ~s(<select class="day-class" id="user_born_at_day" name="user[born_at][day]">)
   end
+
+  test "passing extra options" do
+    code =
+      quote do
+        ~H"""
+        <DateSelect
+          form="user"
+          field="born_at"
+          opts={{ id: "born_at", name: "born_at"}}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~
+             ~s(<select id="born_at_year" name="born_at[year]">)
+
+    assert content =~
+             ~s(<select id="born_at_month" name="born_at[month]">)
+
+    assert content =~
+             ~s(<select id="born_at_day" name="born_at[day]">)
+  end
 end

--- a/test/components/form/datetime_select_test.exs
+++ b/test/components/form/datetime_select_test.exs
@@ -46,7 +46,7 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
     code =
       quote do
         ~H"""
-        <DateTimeSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
+        <DateTimeSelect form="user" field="born_at" value={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} second={{ [] }} />
         """
       end
 
@@ -64,7 +64,7 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
     code =
       quote do
         ~H"""
-        <DateTimeSelect form="user" field="born_at" value={{ { {2020, 10, 9}, {2, 11, 13} } }} opts={{ second: [] }} />
+        <DateTimeSelect form="user" field="born_at" value={{ { {2020, 10, 9}, {2, 11, 13} } }} second={{ [] }} />
         """
       end
 
@@ -78,21 +78,175 @@ defmodule Surface.Components.Form.DateTimeSelectTest do
     assert content =~ ~s(<option value="13" selected="selected">13</option>)
   end
 
-  test "passing other options" do
+  test "setting the default value as map" do
     code =
       quote do
         ~H"""
-        <DateTimeSelect form="user" field="born_at" opts={{ second: [] }} />
+        <DateTimeSelect form="user" field="born_at" default={{ %{year: 2020, month: 10, day: 9, hour: 2, minute: 11, second: 13} }} second={{ [] }} />
         """
       end
 
     content = render_live(code)
 
-    assert content =~ ~s(<select id="user_born_at_year" name="user[born_at][year]">)
-    assert content =~ ~s(<select id="user_born_at_month" name="user[born_at][month]">)
-    assert content =~ ~s(<select id="user_born_at_day" name="user[born_at][day]">)
-    assert content =~ ~s(<select id="user_born_at_hour" name="user[born_at][hour]">)
-    assert content =~ ~s(<select id="user_born_at_minute" name="user[born_at][minute]">)
-    assert content =~ ~s(<select id="user_born_at_second" name="user[born_at][second]">)
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
+  end
+
+  test "setting the default value as tuple" do
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect form="user" field="born_at" default={{ { {2020, 10, 9}, {2, 11, 13} } }} second={{ [] }} />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2020" selected="selected">2020</option>)
+    assert content =~ ~s(<option value="10" selected="selected">October</option>)
+    assert content =~ ~s(<option value="9" selected="selected">09</option>)
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
+  end
+
+  test "passing builder to select" do
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect
+          form="user"
+          field="born_at"
+          builder={{ fn b ->
+            html_escape([
+              "Year: ",
+              b.(:year, class: "year"),
+              "Month: ",
+              b.(:month, class: "month"),
+              "Day: ",
+              b.(:day, class: "day"),
+              "Hour: ",
+              b.(:hour, class: "hour"),
+              "Minute: ",
+              b.(:minute, class: "minute"),
+              "Second: ",
+              b.(:second, class: "second"),
+            ])
+          end }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(Year: <select class="year" id="user_born_at_year")
+    assert content =~ ~s(Month: <select class="month" id="user_born_at_month")
+    assert content =~ ~s(Day: <select class="day" id="user_born_at_day")
+    assert content =~ ~s(Hour: <select class="hour" id="user_born_at_hour")
+    assert content =~ ~s(Minute: <select class="minute" id="user_born_at_minute")
+    assert content =~ ~s(Second: <select class="second" id="user_born_at_second")
+  end
+
+  test "passing options to year, month, day, hour, minute and second" do
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect
+          form="user"
+          field="born_at"
+          year={{ prompt: "Year" }}
+          month={{ prompt: "Month" }}
+          day={{ prompt: "Day" }}
+          hour={{ prompt: "Hour" }}
+          minute={{ prompt: "Minute" }}
+          second={{ prompt: "Second" }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="">Year</option>)
+    assert content =~ ~s(<option value="">Month</option>)
+    assert content =~ ~s(<option value="">Day</option>)
+    assert content =~ ~s(<option value="">Hour</option>)
+    assert content =~ ~s(<option value="">Minute</option>)
+    assert content =~ ~s(<option value="">Second</option>)
+  end
+
+  test "parsing class option in year, month, day, hour, minute and second" do
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect
+          form="user"
+          field="born_at"
+          year={{ class: ["true-class": true, "false-class": false] }}
+          month={{ class: ["true-class": true, "false-class": false] }}
+          day={{ class: "day-class" }}
+          hour={{ class: ["true-class": true, "false-class": false] }}
+          minute={{ class: ["true-class": true, "false-class": false] }}
+          second={{ class: "second-class" }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_year" name="user[born_at][year]">)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_month" name="user[born_at][month]">)
+
+    assert content =~
+             ~s(<select class="day-class" id="user_born_at_day" name="user[born_at][day]">)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_hour" name="user[born_at][hour]">)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_minute" name="user[born_at][minute]">)
+
+    assert content =~
+             ~s(<select class="second-class" id="user_born_at_second" name="user[born_at][second]">)
+  end
+
+  test "passing extra options" do
+    code =
+      quote do
+        ~H"""
+        <DateTimeSelect
+          form="user"
+          field="born_at"
+          second={{ [] }}
+          opts={{ id: "born_at", name: "born_at"}}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~
+             ~s(<select id="born_at_year" name="born_at[year]">)
+
+    assert content =~
+             ~s(<select id="born_at_month" name="born_at[month]">)
+
+    assert content =~
+             ~s(<select id="born_at_day" name="born_at[day]">)
+
+    assert content =~
+             ~s(<select id="born_at_hour" name="born_at[hour]">)
+
+    assert content =~
+             ~s(<select id="born_at_minute" name="born_at[minute]">)
+
+    assert content =~
+             ~s(<select id="born_at_second" name="born_at[second]">)
   end
 end

--- a/test/components/form/time_select_test.exs
+++ b/test/components/form/time_select_test.exs
@@ -40,7 +40,7 @@ defmodule Surface.Components.Form.TimeSelectTest do
     code =
       quote do
         ~H"""
-        <TimeSelect form="alarm" field="time" value={{ %{hour: 2, minute: 11, second: 13} }} opts={{ second: [] }} />
+        <TimeSelect form="alarm" field="time" value={{ %{hour: 2, minute: 11, second: 13} }} second={{ [] }} />
         """
       end
 
@@ -55,7 +55,37 @@ defmodule Surface.Components.Form.TimeSelectTest do
     code =
       quote do
         ~H"""
-        <TimeSelect form="alarm" field="time" value={{ {2, 11, 13} }} opts={{ second: [] }} />
+        <TimeSelect form="alarm" field="time" value={{ {2, 11, 13} }} second={{ [] }} />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
+  end
+
+  test "setting the default value as map" do
+    code =
+      quote do
+        ~H"""
+        <TimeSelect form="alarm" field="time" default={{ %{hour: 2, minute: 11, second: 13} }} second={{ [] }} />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="2" selected="selected">02</option>)
+    assert content =~ ~s(<option value="11" selected="selected">11</option>)
+    assert content =~ ~s(<option value="13" selected="selected">13</option>)
+  end
+
+  test "setting the default value as tuple" do
+    code =
+      quote do
+        ~H"""
+        <TimeSelect form="alarm" field="time" default={{ {2, 11, 13} }} second={{ [] }} />
         """
       end
 
@@ -70,7 +100,7 @@ defmodule Surface.Components.Form.TimeSelectTest do
     code =
       quote do
         ~H"""
-        <TimeSelect form="alarm" field="time" opts={{ second: [] }} />
+        <TimeSelect form="alarm" field="time" second={{ [] }} />
         """
       end
 
@@ -79,5 +109,105 @@ defmodule Surface.Components.Form.TimeSelectTest do
     assert content =~ ~s(<select id="alarm_time_hour" name="alarm[time][hour]">)
     assert content =~ ~s(<select id="alarm_time_minute" name="alarm[time][minute]">)
     assert content =~ ~s(<select id="alarm_time_second" name="alarm[time][second]">)
+  end
+
+  test "passing builder to select" do
+    code =
+      quote do
+        ~H"""
+        <TimeSelect
+          form="user"
+          field="born_at"
+          builder={{ fn b ->
+            html_escape([
+              "Hour: ",
+              b.(:hour, class: "hour"),
+              "Minute: ",
+              b.(:minute, class: "minute"),
+              "Second: ",
+              b.(:second, class: "second"),
+            ])
+          end }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(Hour: <select class="hour" id="user_born_at_hour")
+    assert content =~ ~s(Minute: <select class="minute" id="user_born_at_minute")
+    assert content =~ ~s(Second: <select class="second" id="user_born_at_second")
+  end
+
+  test "passing options to hour, minute and second" do
+    code =
+      quote do
+        ~H"""
+        <TimeSelect
+          form="user"
+          field="born_at"
+          hour={{ prompt: "Hour" }}
+          minute={{ prompt: "Minute" }}
+          second={{ prompt: "Second" }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~ ~s(<option value="">Hour</option>)
+    assert content =~ ~s(<option value="">Minute</option>)
+    assert content =~ ~s(<option value="">Second</option>)
+  end
+
+  test "parsing class option in hour, minute and second" do
+    code =
+      quote do
+        ~H"""
+        <TimeSelect
+          form="user"
+          field="born_at"
+          hour={{ class: ["true-class": true, "false-class": false] }}
+          minute={{ class: ["true-class": true, "false-class": false] }}
+          second={{ class: "second-class" }}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_hour" name="user[born_at][hour]">)
+
+    assert content =~
+             ~s(<select class="true-class" id="user_born_at_minute" name="user[born_at][minute]">)
+
+    assert content =~
+             ~s(<select class="second-class" id="user_born_at_second" name="user[born_at][second]">)
+  end
+
+  test "passing extra options" do
+    code =
+      quote do
+        ~H"""
+        <TimeSelect
+          form="user"
+          field="born_at"
+          second={{ [] }}
+          opts={{ id: "born_at", name: "born_at"}}
+        />
+        """
+      end
+
+    content = render_live(code)
+
+    assert content =~
+             ~s(<select id="born_at_hour" name="born_at[hour]">)
+
+    assert content =~
+             ~s(<select id="born_at_minute" name="born_at[minute]">)
+
+    assert content =~
+             ~s(<select id="born_at_second" name="born_at[second]">)
   end
 end


### PR DESCRIPTION
This pull request:

- add the following props to the `DateTimeSelectComponent`: default, year, month, day, hour, minute, second and builder to
- add the following props to the `TimeSelectComponent`: default, hour, minute, second and builder to
- reintroduce `opts` props to the `DateSelectComponent`
- add tests to ensure options passed through `opts` are correctly handle by the components
- improve docs of components 
