### PR TITLE
Reintroduce opts prop for the SelectComponent

### DIFF
--- a/lib/surface/components/form/select.ex
+++ b/lib/surface/components/form/select.ex
@@ -32,12 +32,15 @@ defmodule Surface.Components.Form.Select do
   @doc "The default value to use when none was sent as parameter"
   prop selected, :any
 
+  @doc "Options list"
+  prop opts, :keyword, default: []
+
   def render(assigns) do
     props = get_non_nil_props(assigns, [:prompt, :selected, class: get_config(:default_class)])
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
-      {{ select(form, field, @options, props) }}
+      {{ select(form, field, @options, props ++ @opts) }}
     </InputContext>
     """
   end

--- a/test/components/form/select_test.exs
+++ b/test/components/form/select_test.exs
@@ -56,7 +56,7 @@ defmodule Surface.Components.Form.SelectTest do
     assert render_live(code) =~ ~r/class="select primary"/
   end
 
-  test "passing other options" do
+  test "setting the prompt" do
     code =
       quote do
         ~H"""
@@ -67,6 +67,38 @@ defmodule Surface.Components.Form.SelectTest do
     assert render_live(code) =~ """
            <select id="user_role" name="user[role]">\
            <option value="">Pick a role</option>\
+           <option value="admin">Admin</option>\
+           <option value="user">User</option>\
+           </select>
+           """
+  end
+
+  test "setting the default selected element" do
+    code =
+      quote do
+        ~H"""
+        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} selected="user"/>
+        """
+      end
+
+    assert render_live(code) =~ """
+           <select id="user_role" name="user[role]">\
+           <option value="admin">Admin</option>\
+           <option value="user" selected="selected">User</option>\
+           </select>
+           """
+  end
+
+  test "passing other options" do
+    code =
+      quote do
+        ~H"""
+        <Select form="user" field="role" options={{ ["Admin": "admin", "User": "user"] }} opts={{ disabled: true }}/>
+        """
+      end
+
+    assert render_live(code) =~ """
+           <select id="user_role" name="user[role]" disabled="disabled">\
            <option value="admin">Admin</option>\
            <option value="user">User</option>\
            </select>


### PR DESCRIPTION
This pull request fixes #220 by reintroducing the `opts` props for the `SelectComponent`