### PR TITLE
Improve validation of built-in assigns

### DIFF
--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -118,11 +118,20 @@ defmodule Surface.API do
     existing_assign = assigns[name]
 
     if existing_assign do
-      message = """
-      cannot use name \"#{assign.name}\". There's already \
-      a #{existing_assign.func} assign with the same name \
-      at line #{existing_assign.line}.\
-      """
+      component_type = Module.get_attribute(caller.module, :component_type)
+      builtin_assign? = name in Surface.Compiler.Helpers.builtin_assigns_by_type(component_type)
+
+      details =
+        if builtin_assign? do
+          "There's already a built-in #{existing_assign.func} assign with the same name"
+        else
+          """
+          There's already a #{existing_assign.func} assign with the same name \
+          at line #{existing_assign.line}\
+          """
+        end
+
+      message = ~s(cannot use name "#{assign.name}". #{details}.)
 
       IOHelper.compile_error(message, caller.file, assign.line)
     else

--- a/lib/surface/component.ex
+++ b/lib/surface/component.ex
@@ -45,6 +45,15 @@ defmodule Surface.Component do
       alias Surface.Constructs.{For, If}
       alias Surface.Components.Context
 
+      @doc "Built-in assign"
+      data socket, :any
+
+      @doc "Built-in assign"
+      data flash, :map
+
+      @doc "Built-in assign"
+      data inner_block, :fun
+
       if unquote(slot_name) != nil do
         def render(var!(assigns)) do
           ~H()

--- a/lib/surface/components/form.ex
+++ b/lib/surface/components/form.ex
@@ -41,7 +41,7 @@ defmodule Surface.Components.Form do
   @doc "Keyword list of errors for the form."
   prop errors, :keyword
 
-  @doc "Keyword list with options to be passed down to `Phoenix.HTML.Tag.tag/2``"
+  @doc "Keyword list with options to be passed down to `Phoenix.HTML.Tag.tag/2`"
   prop opts, :keyword, default: []
 
   @doc "Triggered when the form is changed"

--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -69,6 +69,15 @@ defmodule Surface.LiveComponent do
       The id of the live component (required by LiveView for stateful components).
       """
       prop id, :string, required: true
+
+      @doc "Built-in assign"
+      data socket, :any
+
+      @doc "Built-in assign"
+      data flash, :map
+
+      @doc "Built-in assign"
+      data myself, :any
     end
   end
 

--- a/lib/surface/live_view.ex
+++ b/lib/surface/live_view.ex
@@ -53,6 +53,18 @@ defmodule Surface.LiveView do
       """
       prop session, :map
 
+      @doc "Built-in assign"
+      data socket, :any
+
+      @doc "Built-in assign"
+      data flash, :map
+
+      @doc "Built-in assign"
+      data live_action, :atom
+
+      @doc "Built-in assign"
+      data uploads, :list
+
       use Phoenix.LiveView, unquote(opts)
     end
   end


### PR DESCRIPTION
### Improvements

  - Declare all public built-in assigns (helps with validation and also makes them all available for autocomplete)
  - Raise error on duplicate built-in assign
  - Use a different error message when there's a duplicate built-in assigns
  - Consider only the built-in assings specific for each type (Component, LiveComponet and LiveView)

