### PR TITLE
Stateless components with id don't become stateful

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -173,7 +173,12 @@ defmodule Surface do
         {name, Surface.TypeHandler.runtime_prop_value!(module, name, value, node_alias || module)}
       end)
 
-    props = Keyword.merge(Keyword.merge(default_props(module), dynamic_props), static_props)
+    props =
+      module
+      |> default_props()
+      |> Keyword.merge(dynamic_props)
+      |> Keyword.merge(static_props)
+      |> rename_id_if_stateless(module.component_type())
 
     Map.new(
       props ++
@@ -302,5 +307,16 @@ defmodule Surface do
     """
 
     IOHelper.warn(message, caller, & &1)
+  end
+
+  defp rename_id_if_stateless(props, Surface.Component) do
+    case Keyword.pop(props, :id) do
+      {nil, rest} -> rest
+      {id, rest} -> Keyword.put(rest, :__id__, id)
+    end
+  end
+
+  defp rename_id_if_stateless(props, _type) do
+    props
   end
 end

--- a/lib/surface/base_component.ex
+++ b/lib/surface/base_component.ex
@@ -36,4 +36,15 @@ defmodule Surface.BaseComponent do
       end
     end
   end
+
+  @doc false
+  def restore_private_assigns(socket, %{__surface__: surface, __context__: context}) do
+    socket
+    |> Phoenix.LiveView.assign(:__surface__, surface)
+    |> Phoenix.LiveView.assign(:__context__, context)
+  end
+
+  def restore_private_assigns(socket, _assigns) do
+    socket
+  end
 end

--- a/lib/surface/component.ex
+++ b/lib/surface/component.ex
@@ -23,6 +23,7 @@ defmodule Surface.Component do
   """
 
   alias Surface.IOHelper
+  alias Surface.BaseComponent
 
   defmacro __using__(opts \\ []) do
     slot_name = Keyword.get(opts, :slot)
@@ -76,6 +77,31 @@ defmodule Surface.Component do
   end
 
   defmacro __before_compile__(env) do
+    [quoted_mount(env), quoted_update(env)]
+  end
+
+  defp quoted_update(env) do
+    if Module.defines?(env.module, {:update, 2}) do
+      quote do
+        defoverridable update: 2
+
+        def update(assigns, socket) do
+          assigns = unquote(__MODULE__).restore_id(assigns)
+          {:ok, socket} = super(assigns, socket)
+          {:ok, BaseComponent.restore_private_assigns(socket, assigns)}
+        end
+      end
+    else
+      quote do
+        def update(assigns, socket) do
+          assigns = unquote(__MODULE__).restore_id(assigns)
+          {:ok, assign(socket, assigns)}
+        end
+      end
+    end
+  end
+
+  defp quoted_mount(env) do
     if Module.defines?(env.module, {:mount, 1}) do
       quote do
         defoverridable mount: 1
@@ -90,6 +116,14 @@ defmodule Surface.Component do
           {:ok, Surface.init(socket)}
         end
       end
+    end
+  end
+
+  @doc false
+  def restore_id(assigns) do
+    case Map.pop(assigns, :__id__) do
+      {nil, rest} -> rest
+      {id, rest} -> Map.put(rest, :id, id)
     end
   end
 end

--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -50,6 +50,8 @@ defmodule Surface.LiveComponent do
       end
   """
 
+  alias Surface.BaseComponent
+
   defmacro __using__(_) do
     quote do
       @before_compile Surface.Renderer
@@ -90,17 +92,9 @@ defmodule Surface.LiveComponent do
       quote do
         defoverridable update: 2
 
-        def update(%{__surface__: surface, __context__: context} = assigns, socket) do
-          super(
-            assigns,
-            socket
-            |> Phoenix.LiveView.assign(:__surface__, surface)
-            |> Phoenix.LiveView.assign(:__context__, context)
-          )
-        end
-
         def update(assigns, socket) do
-          super(assigns, socket)
+          {:ok, socket} = super(assigns, socket)
+          {:ok, BaseComponent.restore_private_assigns(socket, assigns)}
         end
       end
     end


### PR DESCRIPTION
Currently, if you define a prop `id`  in a stateless `Surface.Component`, it becomes a stateful component since the id will automatically be passed to `live_component/3`. However, the user may just want to use the `id` to pass it to some HTML node, like:

```
<input id={{ @id }} ... />
```

This PR fixes this issue. 

Related to #226.