### PR TITLE
Set experimental-otp: true on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+          experimental-otp: true
       - run: mix format --check-formatted
         if: matrix.check_formatted
       - name: Install Dependencies


### PR DESCRIPTION
We have `runs-on: ubuntu-latest` but CI tried using Elixir built on ubuntu-14.04. `experimental-otp`
forces the action to use a build from a matching OS: ubuntu-20.04 as of right now.

Ref: https://github.com/actions/setup-elixir/issues/49