### PR TITLE
Allow to define the assign name for slot through the :as option

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -288,7 +288,6 @@ defmodule Surface do
   end
 
   @doc false
-  def slot_assigned?(assigns, :default), do: slot_assigned?(assigns, :__default__)
   def slot_assigned?(%{__surface__: %{provided_templates: slots}}, slot), do: slot in slots
   def slot_assigned?(_, _), do: false
 

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -181,14 +181,13 @@ defmodule Surface do
       |> Keyword.merge(static_props)
       |> rename_id_if_stateless(module.component_type())
 
-    renamed_slot_props =
+    slot_assigns =
       module
-      |> mapping_to_rename_slots_with_as_option()
-      |> rename_slots_props(slot_props)
+      |> map_slots_to_assigns(slot_props)
 
     Map.new(
       props ++
-        renamed_slot_props ++
+        slot_assigns ++
         [
           __surface__: %{
             slots: Map.new(slots),
@@ -199,13 +198,12 @@ defmodule Surface do
     )
   end
 
-  defp mapping_to_rename_slots_with_as_option(module) do
-    module.__slots__()
-    |> Enum.map(fn %{name: name, opts: opts} -> {name, Keyword.get(opts, :as)} end)
-    |> Enum.filter(fn value -> not match?({_, nil}, value) end)
-  end
+  defp map_slots_to_assigns(module, slot_props) do
+    mapping =
+      module.__slots__()
+      |> Enum.map(fn %{name: name, opts: opts} -> {name, Keyword.get(opts, :as)} end)
+      |> Enum.filter(fn value -> not match?({_, nil}, value) end)
 
-  defp rename_slots_props(mapping, slot_props) do
     slot_props
     |> Enum.map(fn {name, info} -> {Keyword.get(mapping, name, name), info} end)
   end

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -181,9 +181,27 @@ defmodule Surface do
       |> Keyword.merge(static_props)
       |> rename_id_if_stateless(module.component_type())
 
+    renaming_slot_mapping =
+      module.__slots__()
+      |> Enum.map(fn %{name: name, opts: opts} ->
+        if renamed = Keyword.get(opts, :as) do
+          {name, renamed}
+        end
+      end)
+      |> Enum.filter(fn
+        nil -> false
+        _ -> true
+      end)
+
+    renamed_slot_props =
+      slot_props
+      |> Enum.map(fn {name, info} ->
+        {Keyword.get(renaming_slot_mapping, name, name), info}
+      end)
+
     Map.new(
       props ++
-        slot_props ++
+        renamed_slot_props ++
         [
           __surface__: %{
             slots: Map.new(slots),

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -121,7 +121,7 @@ defmodule Surface.Compiler.EExEngine do
 
   defp to_expression(
          %AST.Slot{
-           name: name,
+           name: slot_name,
            index: index_ast,
            props: props_expr,
            default: default
@@ -129,8 +129,6 @@ defmodule Surface.Compiler.EExEngine do
          buffer,
          state
        ) do
-    slot_name = if name == :default, do: :__default__, else: name
-
     slot_index =
       case index_ast do
         %AST.AttributeExpr{value: expr} -> expr
@@ -312,11 +310,6 @@ defmodule Surface.Compiler.EExEngine do
     slot_info =
       templates
       |> Enum.map(fn {name, templates_for_slot} ->
-        name =
-          if name == :default,
-            do: :__default__,
-            else: name
-
         state = %{state | context: [:template | state.context]}
 
         nested_templates = handle_templates(component, templates_for_slot, buffer, state)

--- a/lib/surface/components/context.ex
+++ b/lib/surface/components/context.ex
@@ -103,7 +103,7 @@ defmodule Surface.Components.Context do
     ~H"""
     {{
       case context_map(@__context__, @put, @get) do
-        {ctx, props} -> render_block(@inner_block, {:__default__, 0, props, ctx})
+        {ctx, props} -> render_block(@inner_block, {:default, 0, props, ctx})
       end
     }}
     """

--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -58,7 +58,7 @@ defmodule Surface.LiveViewTest do
       quote do
         Surface.LiveViewTest.render_component_with_block(
           Surface.LiveViewTest.BlockWrapper,
-          %{__context__: %{}, __surface__: %{provided_templates: [:__default__]}},
+          %{__context__: %{}, __surface__: %{provided_templates: [:default]}},
           do: unquote(do_block)
         )
       end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -50,6 +50,13 @@ defmodule Surface.APITest do
     assert_raise(CompileError, message, fn -> eval(code) end)
   end
 
+  test "validate :as in slot" do
+    code = "slot label, as: \"default_label\""
+    message = ~r/invalid value for option :as in slot. Expected an atom, got: \"default_label\"/
+
+    assert_raise(CompileError, message, fn -> eval(code) end)
+  end
+
   test "validate duplicate assigns" do
     code = """
     prop label, :string
@@ -72,12 +79,100 @@ defmodule Surface.APITest do
     assert_raise(CompileError, message, fn -> eval(code) end)
 
     code = """
+    prop label, :string
+    slot label
+    """
+
+    message = ~r/cannot use name "label". There's already a prop/
+    assert_raise(CompileError, message, fn -> eval(code) end)
+
+    code = """
+    data label, :string
+    data label, :string
+    """
+
+    message = ~r/cannot use name "label". There's already a data assign/
+    assert_raise(CompileError, message, fn -> eval(code) end)
+
+    code = """
     data label, :string
     prop label, :string
     """
 
     message = ~r/cannot use name "label". There's already a data assign/
     assert_raise(CompileError, message, fn -> eval(code) end)
+
+    code = """
+    data label, :string
+    slot label
+    """
+
+    message = ~r/cannot use name "label". There's already a data assign/
+    assert_raise(CompileError, message, fn -> eval(code) end)
+
+    code = """
+    slot label
+    slot label
+    """
+
+    message = ~r"""
+    cannot use name "label". There's already a slot assign with the same name at line \d.
+    You could use the optional ':as' option in slot macro to name the related assigns.
+    """
+
+    assert_raise(CompileError, message, fn -> eval(code) end)
+
+    code = """
+    slot label
+    data label, :string
+    """
+
+    message = ~r"""
+    cannot use name "label". There's already a slot assign with the same name at line \d.
+    You could use the optional ':as' option in slot macro to name the related assigns.
+    """
+
+    assert_raise(CompileError, message, fn -> eval(code) end)
+
+    code = """
+    slot label
+    prop label, :string
+    """
+
+    message = ~r"""
+    cannot use name "label". There's already a slot assign with the same name at line \d.
+    You could use the optional ':as' option in slot macro to name the related assigns.
+    """
+
+    assert_raise(CompileError, message, fn -> eval(code) end)
+
+    code = """
+    slot label, as: :default_label
+    prop label, :string
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
+    prop label, :string
+    slot label, as: :default_label
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
+    data label, :string
+    slot label, as: :default_label
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
+    slot label, as: :default_label
+    data label, :string
+    """
+
+    assert {:ok, _} = eval(code)
   end
 
   test "validate duplicate built-in assigns for Component" do
@@ -216,9 +311,20 @@ defmodule Surface.APITest do
       end)
     end
 
+    test "validate slot as option" do
+      code = "slot cols, as: [:info, {:a, :b}]"
+
+      message =
+        ~r/invalid value for option :as in slot. Expected an atom, got: \[:info, {:a, :b}\]/
+
+      assert_raise(CompileError, message, fn ->
+        eval(code)
+      end)
+    end
+
     test "validate unknown options" do
       code = "slot cols, a: 1"
-      message = ~r/unknown option :a. Available options: \[:required, :props\]/
+      message = ~r/unknown option :a. Available options: \[:required, :props, :as\]/
 
       assert_raise(CompileError, message, fn ->
         eval(code)

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -311,17 +311,6 @@ defmodule Surface.APITest do
       end)
     end
 
-    test "validate slot as option" do
-      code = "slot cols, as: [:info, {:a, :b}]"
-
-      message =
-        ~r/invalid value for option :as in slot. Expected an atom, got: \[:info, {:a, :b}\]/
-
-      assert_raise(CompileError, message, fn ->
-        eval(code)
-      end)
-    end
-
     test "validate unknown options" do
       code = "slot cols, a: 1"
       message = ~r/unknown option :a. Available options: \[:required, :props, :as\]/

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -145,6 +145,23 @@ defmodule Surface.SlotTest do
     end
   end
 
+  defmodule OuterWithRenamedSlot do
+    use Surface.Component
+
+    slot header, as: :default_header
+
+    prop header, :string
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <slot name="header" />
+        {{ @header }}
+      </div>
+      """
+    end
+  end
+
   defmodule Column do
     use Surface.Component, slot: "cols"
 
@@ -421,6 +438,28 @@ defmodule Surface.SlotTest do
           <td>Name: Second</td>
         </tr>
       </table>
+      """
+    )
+  end
+
+  test "rename slot with :as do not overide other assigns with same name" do
+    code =
+      quote do
+        ~H"""
+        <OuterWithRenamedSlot header="My Header Prop">
+          <template slot="header">
+            My Header Slot
+          </template>
+        </OuterWithRenamedSlot>
+        """
+      end
+
+    assert_html(
+      render_live(code) =~ """
+      <div>
+        My Header Slot
+        My Header Prop
+      </div>
       """
     )
   end

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -459,7 +459,7 @@ defmodule Surface.SlotTest do
     )
   end
 
-  test "rename slot with :as do not overide other assigns with same name" do
+  test "rename slot with :as do not override other assigns with same name" do
     html =
       render_surface do
         ~H"""

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -162,6 +162,23 @@ defmodule Surface.SlotTest do
     end
   end
 
+  defmodule OuterWithDefaultPropAndSlot do
+    use Surface.Component
+
+    slot default, as: :default_slot
+
+    prop default, :string
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <slot />
+        {{ @default }}
+      </div>
+      """
+    end
+  end
+
   defmodule Column do
     use Surface.Component, slot: "cols"
 
@@ -459,6 +476,46 @@ defmodule Surface.SlotTest do
       <div>
         My Header Slot
         My Header Prop
+      </div>
+      """
+    )
+  end
+
+  test "default prop name with a default slot" do
+    code =
+      quote do
+        ~H"""
+        <OuterWithDefaultPropAndSlot default="Default Prop">
+          Default Slot
+        </OuterWithDefaultPropAndSlot>
+        """
+      end
+
+    assert_html(
+      render_live(code) =~ """
+      <div>
+        Default Slot
+        Default Prop
+      </div>
+      """
+    )
+
+    code =
+      quote do
+        ~H"""
+        <OuterWithDefaultPropAndSlot default="Default Prop">
+          <template name="default">
+            Default Slot
+          </template>
+        </OuterWithDefaultPropAndSlot>
+        """
+      end
+
+    assert_html(
+      render_live(code) =~ """
+      <div>
+        Default Slot
+        Default Prop
       </div>
       """
     )

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -460,8 +460,8 @@ defmodule Surface.SlotTest do
   end
 
   test "rename slot with :as do not overide other assigns with same name" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithRenamedSlot header="My Header Prop">
           <template slot="header">
@@ -472,7 +472,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         My Header Slot
         My Header Prop
@@ -482,8 +482,8 @@ defmodule Surface.SlotTest do
   end
 
   test "default prop name with a default slot" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithDefaultPropAndSlot default="Default Prop">
           Default Slot
@@ -492,7 +492,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         Default Slot
         Default Prop
@@ -500,8 +500,8 @@ defmodule Surface.SlotTest do
       """
     )
 
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithDefaultPropAndSlot default="Default Prop">
           <template name="default">
@@ -512,7 +512,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         Default Slot
         Default Prop


### PR DESCRIPTION
This pull request fixes #209 

Changes:

- [x] Add `:as` option to slot
- [x] Remove `__default__` name for `default` prop
- [x] Refactoring
- [ ] Doc
