### PR TITLE
Add render_surface/1 and compile_surface/2 test helpers

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -194,18 +194,6 @@ defmodule Surface do
   end
 
   @doc false
-  def rename_id_if_stateless(props, Surface.Component) do
-    case Keyword.pop(props, :id) do
-      {nil, rest} -> rest
-      {id, rest} -> Keyword.put(rest, :__id__, id)
-    end
-  end
-
-  def rename_id_if_stateless(props, _type) do
-    props
-  end
-
-  @doc false
   def css_class(value) when is_list(value) do
     with {:ok, value} <- Surface.TypeHandler.CssClass.expr_to_value(value, []),
          {:ok, string} <- Surface.TypeHandler.CssClass.value_to_html("class", value) do
@@ -319,5 +307,16 @@ defmodule Surface do
     """
 
     IOHelper.warn(message, caller, & &1)
+  end
+
+  defp rename_id_if_stateless(props, Surface.Component) do
+    case Keyword.pop(props, :id) do
+      {nil, rest} -> rest
+      {id, rest} -> Keyword.put(rest, :__id__, id)
+    end
+  end
+
+  defp rename_id_if_stateless(props, _type) do
+    props
   end
 end

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -194,6 +194,18 @@ defmodule Surface do
   end
 
   @doc false
+  def rename_id_if_stateless(props, Surface.Component) do
+    case Keyword.pop(props, :id) do
+      {nil, rest} -> rest
+      {id, rest} -> Keyword.put(rest, :__id__, id)
+    end
+  end
+
+  def rename_id_if_stateless(props, _type) do
+    props
+  end
+
+  @doc false
   def css_class(value) when is_list(value) do
     with {:ok, value} <- Surface.TypeHandler.CssClass.expr_to_value(value, []),
          {:ok, string} <- Surface.TypeHandler.CssClass.value_to_html("class", value) do
@@ -307,16 +319,5 @@ defmodule Surface do
     """
 
     IOHelper.warn(message, caller, & &1)
-  end
-
-  defp rename_id_if_stateless(props, Surface.Component) do
-    case Keyword.pop(props, :id) do
-      {nil, rest} -> rest
-      {id, rest} -> Keyword.put(rest, :__id__, id)
-    end
-  end
-
-  defp rename_id_if_stateless(props, _type) do
-    props
   end
 end

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -124,22 +124,23 @@ defmodule Surface do
   end
 
   @doc "Retrieve a component's config based on the `key`"
-  defmacro get_config(component, key) do
+  def get_config(component, key) do
     config = get_components_config()
-
-    quote bind_quoted: [config: config, component: component, key: key] do
-      config[component][key]
-    end
+    config[component][key]
   end
 
   @doc "Retrieve the component's config based on the `key`"
   defmacro get_config(key) do
     component = __CALLER__.module
-    config = get_components_config()
 
     quote do
-      unquote(config[component][key])
+      get_config(unquote(component), unquote(key))
     end
+  end
+
+  @doc "Retrieve all component's config"
+  def get_components_config() do
+    Application.get_env(:surface, :components, [])
   end
 
   @doc "Initialize surface state in the socket"
@@ -237,10 +238,6 @@ defmodule Surface do
     meta = %{caller: caller, line: caller.line, node_alias: module}
     {type, _opts} = Surface.TypeHandler.attribute_type_and_opts(module, prop_name, meta)
     Surface.TypeHandler.attr_to_opts!(type, prop_name, prop_value)
-  end
-
-  defp get_components_config() do
-    Application.get_env(:surface, :components, [])
   end
 
   @doc """

--- a/lib/surface/components/form/date_input.ex
+++ b/lib/surface/components/form/date_input.ex
@@ -22,7 +22,7 @@ defmodule Surface.Components.Form.DateInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/datetime_local_input.ex
+++ b/lib/surface/components/form/datetime_local_input.ex
@@ -22,7 +22,7 @@ defmodule Surface.Components.Form.DateTimeLocalInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/email_input.ex
+++ b/lib/surface/components/form/email_input.ex
@@ -21,7 +21,7 @@ defmodule Surface.Components.Form.EmailInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/file_input.ex
+++ b/lib/surface/components/form/file_input.ex
@@ -25,7 +25,7 @@ defmodule Surface.Components.Form.FileInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/input.ex
+++ b/lib/surface/components/form/input.ex
@@ -5,6 +5,7 @@ defmodule Surface.Components.Form.Input do
     quote do
       use Surface.Component
 
+      import unquote(__MODULE__)
       alias Surface.Components.Form.Input.InputContext
 
       @doc "An identifier for the form"
@@ -42,9 +43,18 @@ defmodule Surface.Components.Form.Input do
 
       @doc "Triggered when a button on the keyboard is released"
       prop keyup, :event
-
-      @default_class get_config(:default_class) || get_config(unquote(__MODULE__), :default_class)
     end
+  end
+
+  defmacro get_default_class() do
+    quote do
+      unquote(__MODULE__).get_default_class(__MODULE__)
+    end
+  end
+
+  def get_default_class(component) do
+    config = Surface.get_components_config()
+    config[component][:default_class] || config[__MODULE__][:default_class]
   end
 
   defmodule InputContext do

--- a/lib/surface/components/form/number_input.ex
+++ b/lib/surface/components/form/number_input.ex
@@ -21,7 +21,7 @@ defmodule Surface.Components.Form.NumberInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/password_input.ex
+++ b/lib/surface/components/form/password_input.ex
@@ -21,7 +21,7 @@ defmodule Surface.Components.Form.PasswordInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/search_input.ex
+++ b/lib/surface/components/form/search_input.ex
@@ -21,7 +21,7 @@ defmodule Surface.Components.Form.SearchInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/telephone_input.ex
+++ b/lib/surface/components/form/telephone_input.ex
@@ -24,7 +24,7 @@ defmodule Surface.Components.Form.TelephoneInput do
   prop pattern, :string
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, :pattern, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, :pattern, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -21,7 +21,7 @@ defmodule Surface.Components.Form.TextInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/textarea.ex
+++ b/lib/surface/components/form/textarea.ex
@@ -27,7 +27,7 @@ defmodule Surface.Components.Form.TextArea do
   prop cols, :string
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, :rows, :cols, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, :rows, :cols, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/time_input.ex
+++ b/lib/surface/components/form/time_input.ex
@@ -22,7 +22,7 @@ defmodule Surface.Components.Form.TimeInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/components/form/url_input.ex
+++ b/lib/surface/components/form/url_input.ex
@@ -21,7 +21,7 @@ defmodule Surface.Components.Form.UrlInput do
   import Surface.Components.Form.Utils
 
   def render(assigns) do
-    props = get_non_nil_props(assigns, [:value, class: @default_class])
+    props = get_non_nil_props(assigns, [:value, class: get_default_class()])
     event_opts = get_events_to_opts(assigns)
 
     ~H"""

--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -21,6 +21,7 @@ defmodule Surface.LiveViewTest do
 
   defmacro __using__(_opts) do
     quote do
+      import Phoenix.ConnTest
       import Phoenix.LiveViewTest
       import Phoenix.LiveView.Helpers, only: [live_component: 3, live_component: 4]
       import Surface, only: [sigil_H: 2]
@@ -35,7 +36,7 @@ defmodule Surface.LiveViewTest do
   that don't require a parent live view during the tests.
 
   For tests depending on the existence of a parent live view, e.g. testing events on live
-  components and its side-effects, you need to use either `render_live/2` or
+  components and its side-effects, you need to use either `Phoenix.LiveViewTest.live/2` or
   `Phoenix.LiveViewTest.live_isolated/3`.
 
   ## Example

--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -1,0 +1,101 @@
+defmodule Surface.LiveViewTest do
+  @moduledoc """
+  Conveniences for testing Surface components.
+  """
+
+  alias Surface.TypeHandler
+
+  @doc """
+  Helper function to test stateless components or regular rendering of a live component.
+
+  The values passed in `assigns` must be in the runtime format. For instance, a property
+  of type `:css_class` must be passed as list (e.g. `["btn", "active"]`). A property of
+  type `:event` must be passed as `%{name: event_name, target: :live_view}`. This function
+  accepts a block that will be used to fill in the default slot.
+
+  ## Example
+
+      html =
+        render_surface_component(Link, to: "/users/1") do
+          ~H"\""
+          <span>user</span>
+          "\""
+        end
+
+      assert html =~ "\""
+            <a href="/users/1"><span>user</span></a>
+            "\""
+
+  ## Limitations
+
+  Currently, this function cannot be used to test:
+
+    * Slot props
+    * Named slots
+    * Contexts
+    * Events on live components
+
+  If your test depends on any of the features above, you need to use either
+  `render_live/2` or `Phoenix.LiveViewTest.live_isolated/3`.
+
+  """
+  defmacro render_surface_component(component, assigns, opts \\ []) do
+    block = Keyword.get(opts, :do)
+
+    init_inner_block =
+      if block do
+        quote do
+          var!(assigns) = %{}
+          inner_block = unquote(block)
+        end
+      else
+        quote do
+          inner_block = nil
+        end
+      end
+
+    quote do
+      unquote(init_inner_block)
+
+      render_component(
+        unquote(component),
+        unquote(__MODULE__).init_surface(unquote(component), inner_block, unquote(assigns)),
+        unquote(opts)
+      )
+      |> unquote(__MODULE__).clean_html()
+    end
+  end
+
+  @doc false
+  def init_surface(component, inner_block, assigns \\ []) do
+    props =
+      component
+      |> Surface.default_props()
+      |> Keyword.merge(assigns)
+      |> to_runtime_values(component)
+      |> Surface.rename_id_if_stateless(component.component_type())
+      |> Map.new()
+
+    if inner_block do
+      props
+      |> Map.put(:inner_block, fn _, _ -> inner_block end)
+      |> Map.put(:__surface__, %{provided_templates: [:__default__]})
+    else
+      props
+      |> Map.put(:__surface__, %{provided_templates: []})
+    end
+  end
+
+  @doc false
+  def clean_html(html) do
+    html
+    |> String.replace(~r/\n+/, "\n")
+    |> String.replace(~r/\n\s+\n/, "\n")
+  end
+
+  defp to_runtime_values(assigns, component) do
+    Enum.map(assigns, fn {name, value} ->
+      {name, TypeHandler.runtime_prop_value!(component, name, value, component)}
+    end)
+  end
+end

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -1,145 +1,134 @@
 defmodule Surface.Components.Form.TextInputTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
   import ComponentTestHelper
-  alias Surface.Components.Form.TextInput, warn: false
+  alias Surface.Components.Form.TextInput
 
   test "empty input" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="name" />
-        """
-      end
+    html = render_surface_component(TextInput, form: :user, field: :name)
 
-    assert render_live(code) =~ """
-           <input id="user_name" name="user[name]" type="text"/>
+    assert html =~ """
+           <input id="user_name" name="user[name]" type="text">
            """
   end
 
   test "setting the value" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="name" value="Max" />
-        """
-      end
+    html = render_surface_component(TextInput, form: :user, field: :name, value: "Max")
 
-    assert render_live(code) =~ """
-           <input id="user_name" name="user[name]" type="text" value="Max"/>
+    assert html =~ """
+           <input id="user_name" name="user[name]" type="text" value="Max">
            """
   end
 
   test "setting the class" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="name" class="input" />
-        """
-      end
+    html = render_surface_component(TextInput, form: :user, field: :name, class: ["input"])
 
-    assert render_live(code) =~ ~r/class="input"/
+    assert html =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="name" class="input primary" />
-        """
-      end
+    html =
+      render_surface_component(TextInput, form: :user, field: :name, class: ["input", "primary"])
 
-    assert render_live(code) =~ ~r/class="input primary"/
+    assert html =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="name" opts={{ autofocus: "autofocus" }} />
-        """
-      end
+    html =
+      render_surface_component(TextInput,
+        form: :user,
+        field: :name,
+        opts: [autofocus: "autofocus"]
+      )
 
-    assert render_live(code) =~ """
-           <input autofocus="autofocus" id="user_name" name="user[name]" type="text"/>
+    assert html =~ """
+           <input autofocus="autofocus" id="user_name" name="user[name]" type="text">
            """
   end
 
   test "blur event with parent live view as target" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="color" value="Max" blur="my_blur" />
-        """
-      end
+    html =
+      render_surface_component(
+        TextInput,
+        form: :user,
+        field: :color,
+        value: "Max",
+        blur: %{name: "my_blur", target: :live_view}
+      )
 
-    assert render_live(code) =~ """
-           <input id="user_color" name="user[color]" phx-blur="my_blur" type="text" value="Max"/>
+    assert html =~ """
+           <input id="user_color" name="user[color]" phx-blur="my_blur" type="text" value="Max">
            """
   end
 
   test "focus event with parent live view as target" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="color" value="Max" focus="my_focus" />
-        """
-      end
+    html =
+      render_surface_component(
+        TextInput,
+        form: :user,
+        field: :color,
+        value: "Max",
+        focus: %{name: "my_focus", target: :live_view}
+      )
 
-    assert render_live(code) =~ """
-           <input id="user_color" name="user[color]" phx-focus="my_focus" type="text" value="Max"/>
+    assert html =~ """
+           <input id="user_color" name="user[color]" phx-focus="my_focus" type="text" value="Max">
            """
   end
 
   test "capture click event with parent live view as target" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="color" value="Max" capture_click="my_click" />
-        """
-      end
+    html =
+      render_surface_component(TextInput,
+        form: :user,
+        field: :color,
+        value: "Max",
+        capture_click: %{name: "my_click", target: :live_view}
+      )
 
-    assert render_live(code) =~ """
-           <input id="user_color" name="user[color]" phx-capture-click="my_click" type="text" value="Max"/>
+    assert html =~ """
+           <input id="user_color" name="user[color]" phx-capture-click="my_click" type="text" value="Max">
            """
   end
 
   test "keydown event with parent live view as target" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="color" value="Max" keydown="my_keydown" />
-        """
-      end
+    html =
+      render_surface_component(TextInput,
+        form: :user,
+        field: :color,
+        value: "Max",
+        keydown: %{name: "my_keydown", target: :live_view}
+      )
 
-    assert render_live(code) =~ """
-           <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="text" value="Max"/>
+    assert html =~ """
+           <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="text" value="Max">
            """
   end
 
   test "keyup event with parent live view as target" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="color" value="Max" keyup="my_keyup" />
-        """
-      end
+    html =
+      render_surface_component(TextInput,
+        form: :user,
+        field: :color,
+        value: "Max",
+        keyup: %{name: "my_keyup", target: :live_view}
+      )
 
-    assert render_live(code) =~ """
-           <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="text" value="Max"/>
+    assert html =~ """
+           <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="text" value="Max">
            """
   end
 
   test "setting id and name through props" do
-    code =
-      quote do
-        ~H"""
-        <TextInput form="user" field="name" id="username" name="username" />
-        """
-      end
+    html =
+      render_surface_component(TextInput,
+        form: :user,
+        field: :name,
+        id: "username",
+        name: "username"
+      )
 
-    assert render_live(code) =~ """
-           <input id="username" name="username" type="text"/>
+    assert html =~ """
+           <input id="username" name="username" type="text">
            """
   end
 end

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -144,21 +144,20 @@ defmodule Surface.Components.Form.TextInputTest do
 end
 
 defmodule Surface.Components.Form.TextInputConfigTest do
-  use ExUnit.Case
+  use Surface.ConnCase
 
-  import ComponentTestHelper
   alias Surface.Components.Form.TextInput, warn: false
 
   test ":default_class config" do
     using_config TextInput, default_class: "default_class" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <TextInput/>
           """
         end
 
-      assert render_live(code) =~ ~r/class="default_class"/
+      assert html =~ ~r/class="default_class"/
     end
   end
 end

--- a/test/components/form/text_input_test.exs
+++ b/test/components/form/text_input_test.exs
@@ -1,11 +1,15 @@
 defmodule Surface.Components.Form.TextInputTest do
   use Surface.ConnCase, async: true
 
-  import ComponentTestHelper
   alias Surface.Components.Form.TextInput
 
   test "empty input" do
-    html = render_surface_component(TextInput, form: :user, field: :name)
+    html =
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="name" />
+        """
+      end
 
     assert html =~ """
            <input id="user_name" name="user[name]" type="text">
@@ -13,7 +17,12 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "setting the value" do
-    html = render_surface_component(TextInput, form: :user, field: :name, value: "Max")
+    html =
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="name" value="Max" />
+        """
+      end
 
     assert html =~ """
            <input id="user_name" name="user[name]" type="text" value="Max">
@@ -21,25 +30,34 @@ defmodule Surface.Components.Form.TextInputTest do
   end
 
   test "setting the class" do
-    html = render_surface_component(TextInput, form: :user, field: :name, class: ["input"])
+    html =
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="name" class="input" />
+        """
+      end
 
     assert html =~ ~r/class="input"/
   end
 
   test "setting multiple classes" do
     html =
-      render_surface_component(TextInput, form: :user, field: :name, class: ["input", "primary"])
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="name" class="input primary" />
+        """
+      end
 
     assert html =~ ~r/class="input primary"/
   end
 
   test "passing other options" do
     html =
-      render_surface_component(TextInput,
-        form: :user,
-        field: :name,
-        opts: [autofocus: "autofocus"]
-      )
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="name" opts={{ autofocus: "autofocus" }} />
+        """
+      end
 
     assert html =~ """
            <input autofocus="autofocus" id="user_name" name="user[name]" type="text">
@@ -48,13 +66,11 @@ defmodule Surface.Components.Form.TextInputTest do
 
   test "blur event with parent live view as target" do
     html =
-      render_surface_component(
-        TextInput,
-        form: :user,
-        field: :color,
-        value: "Max",
-        blur: %{name: "my_blur", target: :live_view}
-      )
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" blur="my_blur" />
+        """
+      end
 
     assert html =~ """
            <input id="user_color" name="user[color]" phx-blur="my_blur" type="text" value="Max">
@@ -63,13 +79,11 @@ defmodule Surface.Components.Form.TextInputTest do
 
   test "focus event with parent live view as target" do
     html =
-      render_surface_component(
-        TextInput,
-        form: :user,
-        field: :color,
-        value: "Max",
-        focus: %{name: "my_focus", target: :live_view}
-      )
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" focus="my_focus" />
+        """
+      end
 
     assert html =~ """
            <input id="user_color" name="user[color]" phx-focus="my_focus" type="text" value="Max">
@@ -78,12 +92,11 @@ defmodule Surface.Components.Form.TextInputTest do
 
   test "capture click event with parent live view as target" do
     html =
-      render_surface_component(TextInput,
-        form: :user,
-        field: :color,
-        value: "Max",
-        capture_click: %{name: "my_click", target: :live_view}
-      )
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" capture_click="my_click" />
+        """
+      end
 
     assert html =~ """
            <input id="user_color" name="user[color]" phx-capture-click="my_click" type="text" value="Max">
@@ -92,12 +105,11 @@ defmodule Surface.Components.Form.TextInputTest do
 
   test "keydown event with parent live view as target" do
     html =
-      render_surface_component(TextInput,
-        form: :user,
-        field: :color,
-        value: "Max",
-        keydown: %{name: "my_keydown", target: :live_view}
-      )
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" keydown="my_keydown" />
+        """
+      end
 
     assert html =~ """
            <input id="user_color" name="user[color]" phx-keydown="my_keydown" type="text" value="Max">
@@ -106,12 +118,11 @@ defmodule Surface.Components.Form.TextInputTest do
 
   test "keyup event with parent live view as target" do
     html =
-      render_surface_component(TextInput,
-        form: :user,
-        field: :color,
-        value: "Max",
-        keyup: %{name: "my_keyup", target: :live_view}
-      )
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="color" value="Max" keyup="my_keyup" />
+        """
+      end
 
     assert html =~ """
            <input id="user_color" name="user[color]" phx-keyup="my_keyup" type="text" value="Max">
@@ -120,12 +131,11 @@ defmodule Surface.Components.Form.TextInputTest do
 
   test "setting id and name through props" do
     html =
-      render_surface_component(TextInput,
-        form: :user,
-        field: :name,
-        id: "username",
-        name: "username"
-      )
+      render_surface do
+        ~H"""
+        <TextInput form="user" field="name" id="username" name="username" />
+        """
+      end
 
     assert html =~ """
            <input id="username" name="username" type="text">

--- a/test/components/form_test.exs
+++ b/test/components/form_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.Components.FormTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
   alias Surface.Components.Form, warn: false
   alias Surface.Components.Form.TextInput, warn: false
@@ -75,7 +75,7 @@ defmodule Surface.Components.FormTest do
            """
   end
 
-  test "form as a changeset" do
+  test "form as a changeset", %{conn: conn} do
     assigns = %{
       "changeset" =>
         Ecto.Changeset.cast(
@@ -85,11 +85,13 @@ defmodule Surface.Components.FormTest do
         )
     }
 
-    assert render_live(ViewWithForm, assigns) =~ """
+    {:ok, _view, html} = live_isolated(conn, ViewWithForm, session: assigns)
+
+    assert html =~ """
            <form action="#" method="post">\
            <input name="_csrf_token" type="hidden" value="test"/>\
            <input id="user_name" name="user[name]" type="text" value="myname"/>\
-           </form>
+           </form>\
            """
   end
 
@@ -107,7 +109,7 @@ defmodule Surface.Components.FormTest do
            """
   end
 
-  test "form exposes the generated form instance" do
+  test "form exposes the generated form instance", %{conn: conn} do
     assigns = %{
       "changeset" =>
         Ecto.Changeset.cast(
@@ -117,6 +119,8 @@ defmodule Surface.Components.FormTest do
         )
     }
 
-    assert render_live(ViewWithForm, assigns) =~ ~r/Name is invalid/
+    {:ok, _view, html} = live_isolated(conn, ViewWithForm, session: assigns)
+
+    assert html =~ ~r/Name is invalid/
   end
 end

--- a/test/components/link_test.exs
+++ b/test/components/link_test.exs
@@ -20,7 +20,12 @@ defmodule Surface.Components.LinkTest do
   end
 
   test "creates a link with label" do
-    html = render_surface_component(Link, label: "user", to: "/users/1")
+    html =
+      render_surface do
+        ~H"""
+        <Link label="user" to="/users/1" />
+        """
+      end
 
     assert html =~ """
            <a href="/users/1">user</a>
@@ -28,7 +33,12 @@ defmodule Surface.Components.LinkTest do
   end
 
   test "creates a link without label" do
-    html = render_surface_component(Link, to: "/users/1")
+    html =
+      render_surface do
+        ~H"""
+        <Link to="/users/1" />
+        """
+      end
 
     assert html =~ """
            <a href="/users/1"></a>
@@ -37,20 +47,24 @@ defmodule Surface.Components.LinkTest do
 
   test "creates a link with default slot" do
     html =
-      render_surface_component(Link, to: "/users/1") do
+      render_surface do
         ~H"""
-        <span>user</span>
+        <Link to="/users/1"><span>user</span></Link>
         """
       end
 
     assert html =~ """
-           <a href="/users/1"><span>user</span>
-           </a>
+           <a href="/users/1"><span>user</span></a>
            """
   end
 
   test "setting the class" do
-    html = render_surface_component(Link, label: "user", to: "/users/1", class: ["link"])
+    html =
+      render_surface do
+        ~H"""
+        <Link label="user" to="/users/1" class="link" />
+        """
+      end
 
     assert html =~ """
            <a class="link" href="/users/1">user</a>
@@ -59,7 +73,11 @@ defmodule Surface.Components.LinkTest do
 
   test "setting multiple classes" do
     html =
-      render_surface_component(Link, label: "user", to: "/users/1", class: ["link", "primary"])
+      render_surface do
+        ~H"""
+        <Link label="user" to="/users/1" class="link primary" />
+        """
+      end
 
     assert html =~ """
            <a class="link primary" href="/users/1">user</a>
@@ -68,24 +86,35 @@ defmodule Surface.Components.LinkTest do
 
   test "passing other options" do
     html =
-      render_surface_component(Link,
-        label: "user",
-        to: "/users/1",
-        class: ["link"],
-        opts: [method: :delete, data: [confirm: "Really?"], csrf_token: "token"]
-      )
+      render_surface do
+        ~H"""
+        <Link
+          label="user"
+          to="/users/1"
+          class="link"
+          opts={{ method: :delete, data: [confirm: "Really?"], csrf_token: "token" }}
+        />
+        """
+      end
 
     assert html =~ """
-           <a class="link" data-confirm="Really?" data-csrf="token" data-method="delete" data-to="/users/1" href="/users/1" rel="nofollow">user</a>
+           <a class="link" \
+           data-confirm="Really?" \
+           data-csrf="token" \
+           data-method="delete" \
+           data-to="/users/1" \
+           href="/users/1" \
+           rel="nofollow">user</a>
            """
   end
 
   test "click event with parent live view as target" do
     html =
-      render_surface_component(Link,
-        to: "/users/1",
-        click: %{name: "my_click", target: :live_view}
-      )
+      render_surface do
+        ~H"""
+        <Link to="/users/1" click="my_click" />
+        """
+      end
 
     assert html =~ """
            <a href="/users/1" phx-click="my_click"></a>
@@ -93,7 +122,12 @@ defmodule Surface.Components.LinkTest do
   end
 
   test "click event with @myself as target" do
-    html = render_surface_component(ComponentWithLink, id: "comp")
+    html =
+      render_surface do
+        ~H"""
+        <ComponentWithLink id="comp"/>
+        """
+      end
 
     assert html =~ ~r"""
            <div>

--- a/test/components/link_test.exs
+++ b/test/components/link_test.exs
@@ -1,9 +1,7 @@
 defmodule Surface.Components.LinkTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
-  alias Surface.Components.Link, warn: false
-
-  import ComponentTestHelper
+  alias Surface.Components.Link
 
   defmodule ComponentWithLink do
     use Surface.LiveComponent
@@ -21,109 +19,86 @@ defmodule Surface.Components.LinkTest do
     end
   end
 
-  describe "Without LiveView" do
-    test "creates a link with label" do
-      code =
-        quote do
-          ~H"""
-          <Link label="user" to="/users/1" />
-          """
-        end
+  test "creates a link with label" do
+    html = render_surface_component(Link, label: "user", to: "/users/1")
 
-      assert render_live(code) =~ """
-             <a href="/users/1">user</a>
-             """
-    end
+    assert html =~ """
+           <a href="/users/1">user</a>
+           """
+  end
 
-    test "creates a link without label" do
-      code =
-        quote do
-          ~H"""
-          <Link to="/users/1" />
-          """
-        end
+  test "creates a link without label" do
+    html = render_surface_component(Link, to: "/users/1")
 
-      assert render_live(code) =~ """
-             <a href="/users/1"></a>
-             """
-    end
+    assert html =~ """
+           <a href="/users/1"></a>
+           """
+  end
 
-    test "creates a link with default slot" do
-      code =
-        quote do
-          ~H"""
-          <Link to="/users/1"><span>user</span></Link>
-          """
-        end
+  test "creates a link with default slot" do
+    html =
+      render_surface_component(Link, to: "/users/1") do
+        ~H"""
+        <span>user</span>
+        """
+      end
 
-      assert render_live(code) =~ """
-             <a href="/users/1"><span>user</span></a>
-             """
-    end
+    assert html =~ """
+           <a href="/users/1"><span>user</span>
+           </a>
+           """
+  end
 
-    test "setting the class" do
-      code =
-        quote do
-          ~H"""
-          <Link label="user" to="/users/1" class="link" />
-          """
-        end
+  test "setting the class" do
+    html = render_surface_component(Link, label: "user", to: "/users/1", class: ["link"])
 
-      assert render_live(code) =~ """
-             <a class="link" href="/users/1">user</a>
-             """
-    end
+    assert html =~ """
+           <a class="link" href="/users/1">user</a>
+           """
+  end
 
-    test "setting multiple classes" do
-      code =
-        quote do
-          ~H"""
-          <Link label="user" to="/users/1" class="link primary" />
-          """
-        end
+  test "setting multiple classes" do
+    html =
+      render_surface_component(Link, label: "user", to: "/users/1", class: ["link", "primary"])
 
-      assert render_live(code) =~ """
-             <a class="link primary" href="/users/1">user</a>
-             """
-    end
+    assert html =~ """
+           <a class="link primary" href="/users/1">user</a>
+           """
+  end
 
-    test "passing other options" do
-      code =
-        quote do
-          ~H"""
-          <Link label="user" to="/users/1" class="link" opts={{ method: :delete, data: [confirm: "Really?"], csrf_token: "token" }} />
-          """
-        end
+  test "passing other options" do
+    html =
+      render_surface_component(Link,
+        label: "user",
+        to: "/users/1",
+        class: ["link"],
+        opts: [method: :delete, data: [confirm: "Really?"], csrf_token: "token"]
+      )
 
-      assert render_live(code) =~ """
-             <a class="link" data-confirm="Really?" data-csrf="token" data-method="delete" data-to="/users/1" href="/users/1" rel="nofollow">user</a>
-             """
-    end
+    assert html =~ """
+           <a class="link" data-confirm="Really?" data-csrf="token" data-method="delete" data-to="/users/1" href="/users/1" rel="nofollow">user</a>
+           """
+  end
 
-    test "click event with parent live view as target" do
-      code =
-        quote do
-          ~H"""
-          <Link to="/users/1" click="my_click" />
-          """
-        end
+  test "click event with parent live view as target" do
+    html =
+      render_surface_component(Link,
+        to: "/users/1",
+        click: %{name: "my_click", target: :live_view}
+      )
 
-      assert render_live(code) =~ """
-             <a href="/users/1" phx-click="my_click"></a>
-             """
-    end
+    assert html =~ """
+           <a href="/users/1" phx-click="my_click"></a>
+           """
+  end
 
-    test "click event with @myself as target" do
-      code =
-        quote do
-          ~H"""
-          <ComponentWithLink id="comp"/>
-          """
-        end
+  test "click event with @myself as target" do
+    html = render_surface_component(ComponentWithLink, id: "comp")
 
-      assert render_live(code) =~ """
-             <div data-phx-component="1"><a href="/users/1" phx-click="my_click" phx-target="1"></a></div>
-             """
-    end
+    assert html =~ ~r"""
+           <div>
+             <a href="/users/1" phx-click="my_click" phx-target=".+"></a>
+           </div>
+           """
   end
 end

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -1,5 +1,5 @@
 defmodule ContextTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
   import Surface
   import ComponentTestHelper
@@ -84,8 +84,8 @@ defmodule ContextTest do
   end
 
   test "pass context to child component" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Outer>
           <Inner/>
@@ -93,14 +93,14 @@ defmodule ContextTest do
         """
       end
 
-    assert render_live(code) =~ """
+    assert html =~ """
            <span id="field">field from Outer</span>\
            """
   end
 
   test "pass context to child component using :as option" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Outer>
           <InnerWithOptionAs/>
@@ -108,14 +108,16 @@ defmodule ContextTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <div><span>field from Outer</span></div>
+    assert html =~ """
+           <div>
+             <span>field from Outer</span>
+           </div>
            """
   end
 
   test "pass context down the tree of components" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Outer>
           <InnerWrapper />
@@ -123,14 +125,14 @@ defmodule ContextTest do
         """
       end
 
-    assert render_live(code) =~ """
+    assert html =~ """
            <span id="field">field from Outer</span>\
            """
   end
 
   test "context assingns are scoped by their parent components" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Outer>
           <InnerWrapper/>
@@ -138,15 +140,15 @@ defmodule ContextTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <span id="field">field from Outer</span>\
-           <span id="other_field">field from InnerWrapper</span>\
+    assert html =~ """
+           <span id="field">field from Outer</span>
+             <span id="other_field">field from InnerWrapper</span>
            """
   end
 
   test "reset context after the component" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Outer>
           <Inner/>
@@ -155,14 +157,14 @@ defmodule ContextTest do
         """
       end
 
-    assert render_live(code) =~ """
+    assert html =~ """
            Context: %{}
            """
   end
 
   test "pass context to named slots" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithNamedSlots>
           <template slot="my_slot">
@@ -174,7 +176,7 @@ defmodule ContextTest do
         """
       end
 
-    assert render_live(code) =~ "field from OuterWithNamedSlots"
+    assert html =~ "field from OuterWithNamedSlots"
   end
 
   describe "validate property :get" do

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -1,9 +1,6 @@
 defmodule ContextTest do
   use Surface.ConnCase, async: true
 
-  import Surface
-  import ComponentTestHelper
-
   alias Surface.Components.Context
 
   defmodule Outer do
@@ -199,7 +196,7 @@ defmodule ContextTest do
       """
 
       assert_raise(CompileError, message, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
@@ -215,7 +212,7 @@ defmodule ContextTest do
         end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "get"/, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
@@ -231,7 +228,7 @@ defmodule ContextTest do
         end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "get"/, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
   end
@@ -256,7 +253,7 @@ defmodule ContextTest do
       """
 
       assert_raise(CompileError, message, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
@@ -272,7 +269,7 @@ defmodule ContextTest do
         end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "put"/, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
@@ -288,7 +285,7 @@ defmodule ContextTest do
         end
 
       assert_raise(CompileError, ~r/code:2: invalid value for property "put"/, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
   end

--- a/test/context_through_slot_test.exs
+++ b/test/context_through_slot_test.exs
@@ -1,8 +1,5 @@
 defmodule Surface.ContextThroughSlotTest do
-  use ExUnit.Case, async: true
-
-  import Surface
-  import ComponentTestHelper
+  use Surface.ConnCase, async: true
 
   defmodule Parent.ContextProvider do
     use Surface.Component
@@ -60,7 +57,8 @@ defmodule Surface.ContextThroughSlotTest do
     end
   end
 
-  test "child should take context from parent when rendered in slot" do
-    assert render_live(ExampleWeb.ContextLive) =~ "<div><div>bar</div></div>"
+  test "child should take context from parent when rendered in slot", %{conn: conn} do
+    {:ok, _view, html} = live_isolated(conn, ExampleWeb.ContextLive)
+    assert html =~ "<div><div>bar</div></div>"
   end
 end

--- a/test/live_component_events_test.exs
+++ b/test/live_component_events_test.exs
@@ -1,10 +1,6 @@
 defmodule Surface.EventsTest do
   use Surface.ConnCase, async: true
 
-  import ComponentTestHelper
-
-  @endpoint Endpoint
-
   defmodule LiveDiv do
     use Surface.LiveComponent
 
@@ -84,11 +80,9 @@ defmodule Surface.EventsTest do
   test "handle event in the parent liveview" do
     {:ok, _view, html} = live_isolated(build_conn(), View)
 
-    assert_html(
-      html =~ """
-      <button data-phx-component="2" phx-click="click">Click me!</button>
-      """
-    )
+    assert html =~ """
+           <button data-phx-component="2" phx-click="click">Click me!</button>\
+           """
   end
 
   test "handle event in parent component" do
@@ -182,15 +176,6 @@ defmodule Surface.EventsTest do
   end
 
   test "raise error when passing an :event into a phx-* binding" do
-    code =
-      quote do
-        ~H"""
-        <div>
-          <ButtonWithInvalidEvent id="button_id" click={{ "ok" }}/>
-        </div>
-        """
-      end
-
     message = """
     invalid value for "phx-click". LiveView bindings only accept values \
     of type :string. If you want to pass an :event, please use directive \
@@ -198,7 +183,11 @@ defmodule Surface.EventsTest do
     """
 
     assert_raise(RuntimeError, message, fn ->
-      render_live(code)
+      render_surface do
+        ~H"""
+        <ButtonWithInvalidEvent id="button_id" click={{ "ok" }}/>
+        """
+      end
     end)
   end
 end

--- a/test/live_component_events_test.exs
+++ b/test/live_component_events_test.exs
@@ -1,8 +1,6 @@
 defmodule Surface.EventsTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
-  import Phoenix.ConnTest
-  import Phoenix.LiveViewTest
   import ComponentTestHelper
 
   @endpoint Endpoint
@@ -94,8 +92,8 @@ defmodule Surface.EventsTest do
   end
 
   test "handle event in parent component" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <div>
           <Panel id="panel_id"/>
@@ -103,14 +101,14 @@ defmodule Surface.EventsTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <button data-phx-component="2" phx-click="click" phx-target="1"\
+    assert html =~ """
+           <button phx-click="click" phx-target="1"\
            """
   end
 
   test "handle event locally" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <div>
           <Button id="button_id"/>
@@ -118,14 +116,14 @@ defmodule Surface.EventsTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <button data-phx-component="1" phx-click="click" phx-target="1"\
+    assert html =~ """
+           <button phx-click="click" phx-target="1"\
            """
   end
 
   test "override target" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <div>
           <Button id="button_id" click={{ %{name: "ok", target: "#comp"} }}/>
@@ -133,7 +131,7 @@ defmodule Surface.EventsTest do
         """
       end
 
-    assert render_live(code) =~ """
+    assert html =~ """
            phx-click="ok" phx-target="#comp"\
            """
   end
@@ -144,8 +142,8 @@ defmodule Surface.EventsTest do
     """
 
     # Event name as string
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <div>
           <Button id="button_id" click={{ "ok", target: "#comp" }}/>
@@ -153,11 +151,11 @@ defmodule Surface.EventsTest do
         """
       end
 
-    assert render_live(code) =~ expected
+    assert html =~ expected
 
     # Event name as atom
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <div>
           <Button id="button_id" click={{ :ok, target: "#comp" }}/>
@@ -165,20 +163,18 @@ defmodule Surface.EventsTest do
         """
       end
 
-    assert render_live(code) =~ expected
+    assert html =~ expected
   end
 
   test "passing event as nil does not render phx-*" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <div>
           <Button id="button_id" click={{ nil }}/>
         </div>
         """
       end
-
-    html = render_live(code)
 
     assert html =~ "<button"
     refute html =~ "phx-click"

--- a/test/live_component_test.exs
+++ b/test/live_component_test.exs
@@ -1,11 +1,5 @@
 defmodule LiveComponentTest do
-  use ExUnit.Case, async: true
-
-  import Phoenix.ConnTest
-  import Phoenix.LiveViewTest
-  import ComponentTestHelper
-
-  @endpoint Endpoint
+  use Surface.ConnCase, async: true
 
   defmodule StatelessComponent do
     use Surface.Component
@@ -67,9 +61,9 @@ defmodule LiveComponentTest do
       info = "Hi there!"
 
       ~H"""
-        <div>
-          <slot :props={{ info: info }}/>
-        </div>
+      <div>
+        <slot :props={{ info: info }}/>
+      </div>
       """
     end
   end
@@ -79,9 +73,9 @@ defmodule LiveComponentTest do
 
     def render(assigns) do
       ~H"""
-        <div>
-          <slot/>
-        </div>
+      <div>
+        <slot/>
+      </div>
       """
     end
   end
@@ -111,8 +105,8 @@ defmodule LiveComponentTest do
   end
 
   test "render content without slot props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <InfoProviderWithoutSlotProps>
           <span>Hi there!</span>
@@ -120,14 +114,16 @@ defmodule LiveComponentTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <div><span>Hi there!</span></div>
+    assert html =~ """
+           <div>
+             <span>Hi there!</span>
+           </div>
            """
   end
 
   test "render content with slot props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <InfoProvider :let={{ info: my_info }}>
           <span>{{ my_info }}</span>
@@ -135,33 +131,35 @@ defmodule LiveComponentTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <div><span>Hi there!</span></div>
+    assert html =~ """
+           <div>
+             <span>Hi there!</span>
+           </div>
            """
   end
 
   test "render stateful component with event" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <LiveComponentWithEvent event="click-event" id="button" />
         """
       end
 
-    assert render_live(code) =~ """
-           <button data-phx-component=\"1\" phx-click=\"click-event\"></button>
+    assert html =~ """
+           <button phx-click=\"click-event\"></button>
            """
   end
 
   test "do not set assign for `data` without default value" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <LiveComponentDataWithoutDefault id="counter"/>
         """
       end
 
-    assert render_live(code) =~ "false"
+    assert html =~ "false"
   end
 
   test "render stateless component" do

--- a/test/live_view_test.exs
+++ b/test/live_view_test.exs
@@ -1,7 +1,5 @@
 defmodule LiveViewTest do
-  use ExUnit.Case, async: true
-
-  import ComponentTestHelper
+  use Surface.ConnCase, async: true
 
   defmodule LiveViewDataWithoutDefault do
     use Surface.LiveView
@@ -15,7 +13,8 @@ defmodule LiveViewTest do
     end
   end
 
-  test "do not set assign for `data` without default value" do
-    assert render_live(LiveViewDataWithoutDefault) =~ "false"
+  test "do not set assign for `data` without default value", %{conn: conn} do
+    {:ok, _view, html} = live_isolated(conn, LiveViewDataWithoutDefault)
+    assert html =~ "false"
   end
 end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -1,8 +1,6 @@
 defmodule Surface.PropertiesTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
-  import Surface
-  import ComponentTestHelper
   import ExUnit.CaptureIO
 
   defmodule StringProp do
@@ -95,14 +93,16 @@ defmodule Surface.PropertiesTest do
 
   describe "string" do
     test "passing a string with interpolation" do
-      code =
-        quote do
+      assigns = %{a: 1, b: "two"}
+
+      html =
+        render_surface do
           ~H"""
           <StringProp label="begin {{ @a }} {{ @b }} end"/>
           """
         end
 
-      assert render_live(code, %{a: 1, b: "two"}) =~ "begin 1 two end"
+      assert html =~ "begin 1 two end"
     end
 
     test "raise error on the right line for string with interpolation" do
@@ -140,14 +140,14 @@ defmodule Surface.PropertiesTest do
 
   describe "keyword" do
     test "passing a keyword list" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <KeywordProp prop={{ [option1: 1, option2: 2] }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              Keyword?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -155,14 +155,14 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list without brackets" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <KeywordProp prop={{ option1: 1, option2: 2 }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              Keyword?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -172,14 +172,14 @@ defmodule Surface.PropertiesTest do
     test "passing a keyword list as an expression" do
       assigns = %{submit: [option1: 1, option2: 2]}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <KeywordProp prop={{ @submit }}/>
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              Keyword?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -198,20 +198,11 @@ defmodule Surface.PropertiesTest do
         ~S(code:1: invalid value for property "prop". Expected a :keyword, got: "some string".)
 
       assert_raise(CompileError, message, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
     test "validate invalid values at runtime" do
-      assigns = %{var: 1}
-
-      code =
-        quote do
-          ~H"""
-          <KeywordProp prop={{ @var }}/>
-          """
-        end
-
       message = """
       invalid value for property "prop". Expected a :keyword, got: 1.
 
@@ -219,21 +210,27 @@ defmodule Surface.PropertiesTest do
       """
 
       assert_raise(RuntimeError, message, fn ->
-        render_live(code, assigns)
+        assigns = %{var: 1}
+
+        render_surface do
+          ~H"""
+          <KeywordProp prop={{ @var }}/>
+          """
+        end
       end)
     end
   end
 
   describe "map" do
     test "passing a map" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <MapProp prop={{ %{option1: 1, option2: 2} }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              Map?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -241,14 +238,14 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <MapProp prop={{ [option1: 1, option2: 2] }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              Map?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -256,14 +253,14 @@ defmodule Surface.PropertiesTest do
     end
 
     test "passing a keyword list without brackets" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <MapProp prop={{ option1: 1, option2: 2 }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              Map?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -273,14 +270,14 @@ defmodule Surface.PropertiesTest do
     test "passing a map as an expression" do
       assigns = %{submit: %{option1: 1, option2: 2}}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <MapProp prop={{ @submit }}/>
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              Map?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -290,14 +287,14 @@ defmodule Surface.PropertiesTest do
     test "passing a keyword list as an expression" do
       assigns = %{submit: [option1: 1, option2: 2]}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <MapProp prop={{ @submit }}/>
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              Map?: true
              <span>key: option1, value: 1</span>\
              <span>key: option2, value: 2</span>
@@ -316,20 +313,11 @@ defmodule Surface.PropertiesTest do
         ~S(code:1: invalid value for property "prop". Expected a :map, got: "some string".)
 
       assert_raise(CompileError, message, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
     test "validate invalid values at runtime" do
-      assigns = %{var: 1}
-
-      code =
-        quote do
-          ~H"""
-          <MapProp prop={{ @var }}/>
-          """
-        end
-
       message = """
       invalid value for property "prop". Expected a :map, got: 1.
 
@@ -337,21 +325,27 @@ defmodule Surface.PropertiesTest do
       """
 
       assert_raise(RuntimeError, message, fn ->
-        render_live(code, assigns)
+        assigns = %{var: 1}
+
+        render_surface do
+          ~H"""
+          <MapProp prop={{ @var }}/>
+          """
+        end
       end)
     end
   end
 
   describe "list" do
     test "passing a list" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <ListProp prop={{ [1, 2] }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              List?: true
              <span>value: 1</span>\
              <span>value: 2</span>
@@ -361,14 +355,14 @@ defmodule Surface.PropertiesTest do
     test "passing a list as an expression" do
       assigns = %{submit: [1, 2]}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <ListProp prop={{ @submit }}/>
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              List?: true
              <span>value: 1</span>\
              <span>value: 2</span>
@@ -378,14 +372,14 @@ defmodule Surface.PropertiesTest do
     test "passing a list with a single value as an expression" do
       assigns = %{submit: [1]}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <ListProp prop={{ @submit }}/>
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              List?: true
              <span>value: 1</span>
              """
@@ -402,48 +396,45 @@ defmodule Surface.PropertiesTest do
       message = ~S(code:1: invalid value for property "prop". Expected a :list, got: {{ 1, 2 }}.)
 
       assert_raise(CompileError, message, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
     test "passing a list with a single value without brackets is invalid" do
-      code =
-        quote do
+      message = "invalid value for property \"prop\". Expected a :list, got: 1"
+
+      assert_raise(RuntimeError, message, fn ->
+        render_surface do
           ~H"""
           <ListProp prop={{ 1 }}/>
           """
         end
-
-      message = "invalid value for property \"prop\". Expected a :list, got: 1"
-
-      assert_raise(RuntimeError, message, fn ->
-        render_live(code)
       end)
     end
 
     test "passing a keyword list" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <ListProp prop={{ [a: 1, b: 2] }}/>
           """
         end
 
-      assert render_live(code, %{}) =~ """
+      assert html =~ """
              List?: true
              <span>value: {:a, 1}</span><span>value: {:b, 2}</span>
              """
     end
 
     test "passing a keyword list without brackets" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <ListProp prop={{ a: 1, b: 2 }}/>
           """
         end
 
-      assert render_live(code, %{}) =~ """
+      assert html =~ """
              List?: true
              <span>value: {:a, 1}</span><span>value: {:b, 2}</span>
              """
@@ -461,99 +452,96 @@ defmodule Surface.PropertiesTest do
         ~S(code:1: invalid value for property "prop". Expected a :list, got: "some string".)
 
       assert_raise(CompileError, message, fn ->
-        render_live(code)
+        compile_surface(code)
       end)
     end
 
     test "validate invalid values at runtime" do
-      code =
-        quote do
+      message = "invalid value for property \"prop\". Expected a :list, got: %{test: 1}"
+
+      assert_raise(RuntimeError, message, fn ->
+        render_surface do
           ~H"""
           <ListProp prop={{ %{test: 1} }}/>
           """
         end
-
-      message = "invalid value for property \"prop\". Expected a :list, got: %{test: 1}"
-
-      assert_raise(RuntimeError, message, fn ->
-        render_live(code)
       end)
     end
   end
 
   describe "css_class" do
     test "passing a string" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <CSSClassProp prop="class1 class2"/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              <span class="class1 class2"></span>
              """
     end
 
     test "passing a keywod list" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <CSSClassProp prop={{ [class1: true, class2: false, class3: "truthy"] }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              <span class="class1 class3"></span>
              """
     end
 
     test "passing a keywod list without brackets" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <CSSClassProp prop={{ class1: true, class2: false, class3: "truthy" }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              <span class="class1 class3"></span>
              """
     end
 
     test "trim class items" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <CSSClassProp prop={{ "", " class1 " , "", " ", "  ", " class2 class3 ", "" }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              <span class="class1 class2 class3"></span>
              """
     end
 
     test "values are always converted to a list of strings" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <CSSClassPropInspect prop="class1 class2   class3"/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              <div>class1</div><div>class2</div><div>class3</div>
              """
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <CSSClassPropInspect prop={{ ["class1"] ++ ["class2 class3", :class4, class5: true] }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              <div>class1</div><div>class2</div><div>class3</div><div>class4</div><div>class5</div>
              """
     end
@@ -561,14 +549,14 @@ defmodule Surface.PropertiesTest do
 
   describe "accumulate" do
     test "if true, groups all props with the same name in a single list" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <AccumulateProp prop="str_1" prop={{ "str_2" }}/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              List?: true
              <span>value: str_1</span>\
              <span>value: str_2</span>
@@ -576,28 +564,28 @@ defmodule Surface.PropertiesTest do
     end
 
     test "if true and there's a single prop, it stills creates a list" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <AccumulateProp prop="str_1"/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              List?: true
              <span>value: str_1</span>
              """
     end
 
     test "without any props, takes the default value" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <AccumulateProp/>
           """
         end
 
-      assert render_live(code) =~ """
+      assert html =~ """
              List?: true
              <span>value: default</span>
              """

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -1,11 +1,9 @@
 defmodule Surface.RendererTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
   alias Surface.RendererTest.Components.ComponentWithExternalTemplate
   alias Surface.RendererTest.Components.LiveComponentWithExternalTemplate
   alias Surface.RendererTest.Components.LiveViewWithExternalTemplate
-
-  import ComponentTestHelper
 
   defmodule View do
     use Surface.LiveView
@@ -19,15 +17,18 @@ defmodule Surface.RendererTest do
     end
   end
 
-  test "Component rendering external template" do
-    assert render_live(View) =~ "the rendered content of the component"
+  test "Component rendering external template", %{conn: conn} do
+    {:ok, _view, html} = live_isolated(conn, View)
+    assert html =~ "the rendered content of the component"
   end
 
-  test "LiveComponent rendering external template" do
-    assert render_live(View) =~ "the rendered content of the live component"
+  test "LiveComponent rendering external template", %{conn: conn} do
+    {:ok, _view, html} = live_isolated(conn, View)
+    assert html =~ "the rendered content of the live component"
   end
 
-  test "LiveView rendering external template" do
-    assert render_live(View) =~ "the rendered content of the live view"
+  test "LiveView rendering external template", %{conn: conn} do
+    {:ok, _view, html} = live_isolated(conn, View)
+    assert html =~ "the rendered content of the live view"
   end
 end

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.SlotTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
   import ComponentTestHelper
 
@@ -189,8 +189,8 @@ defmodule Surface.SlotTest do
   end
 
   test "render slot without slot props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithMultipleSlotableEntries>
           Content 1
@@ -210,11 +210,11 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         <div>
           label 1:<b>content 1</b>
-          <div data-phx-component="1">Stateful</div>
+          <div>Stateful</div>
         </div>
         <div>
           label 2:<b>content 2</b>
@@ -224,7 +224,7 @@ defmodule Surface.SlotTest do
           Content 2
             Content 2.1
           Content 3
-          <div data-phx-component="2">Stateful</div>
+          <div>Stateful</div>
         </div>
       </div>
       """
@@ -232,8 +232,8 @@ defmodule Surface.SlotTest do
   end
 
   test "assign named slots with props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithNamedSlotAndProps>
           <template slot="body" :let={{ info: my_info }}>
@@ -244,7 +244,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         Info: Info from slot
       </div>
@@ -253,8 +253,8 @@ defmodule Surface.SlotTest do
   end
 
   test "assign default slot with props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithDefaultSlotAndProps :let={{ info: my_info }}>
           Info: {{ my_info }}
@@ -263,7 +263,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         Info: Info from slot
       </div>
@@ -272,8 +272,8 @@ defmodule Surface.SlotTest do
   end
 
   test "assign default slot ignoring all props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithDefaultSlotAndProps>
           Info
@@ -282,7 +282,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         Info
       </div>
@@ -291,8 +291,8 @@ defmodule Surface.SlotTest do
   end
 
   test "assign named slots without props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithNamedSlot>
           <template slot="header">
@@ -307,7 +307,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         My header
         My body
@@ -318,8 +318,8 @@ defmodule Surface.SlotTest do
   end
 
   test "assign undeclared slots without props" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithoutDeclaringSlots>
           <template slot="header">
@@ -334,7 +334,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         My header
         My body
@@ -345,15 +345,15 @@ defmodule Surface.SlotTest do
   end
 
   test "fallback content" do
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithNamedSlot/>
         """
       end
 
     assert_html(
-      render_live(code) =~ """
+      html =~ """
       <div>
         Default fallback
         Footer fallback
@@ -365,8 +365,8 @@ defmodule Surface.SlotTest do
   test "slotable component with default value for prop" do
     assigns = %{items: [%{id: 1, name: "First"}, %{id: 2, name: "Second"}]}
 
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Grid items={{ user <- @items }}>
           <ColumnWithDefaultTitle>
@@ -377,7 +377,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code, assigns) =~ """
+      html =~ """
       <table>
         <tr>
           <th>default title</th>
@@ -394,8 +394,8 @@ defmodule Surface.SlotTest do
   test "render slot with slot props containing parent bindings" do
     assigns = %{items: [%{id: 1, name: "First"}, %{id: 2, name: "Second"}]}
 
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Grid items={{ user <- @items }}>
           <Column title="ID">
@@ -409,7 +409,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code, assigns) =~ """
+      html =~ """
       <table>
         <tr>
           <th>ID</th><th>NAME</th>
@@ -428,8 +428,8 @@ defmodule Surface.SlotTest do
   test "render slot renaming slot props" do
     assigns = %{items: [%{id: 1, name: "First"}]}
 
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <Grid items={{ user <- @items }}>
           <Column title="ID" :let={{ item: my_user }}>
@@ -444,7 +444,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code, assigns) =~ """
+      html =~ """
       <table>
         <tr>
           <th>ID</th><th>NAME</th>
@@ -646,15 +646,15 @@ defmodule Surface.SlotTest do
   test "does not render slot if slot_assigned? returns false" do
     assigns = %{}
 
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithOptionalNamedSlot />
         """
       end
 
     assert_html(
-      render_live(code, assigns) =~ """
+      html =~ """
       <div>
         <footer>
           Footer fallback
@@ -663,8 +663,8 @@ defmodule Surface.SlotTest do
       """
     )
 
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithOptionalNamedSlot>
           <template slot="header">
@@ -675,7 +675,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code, assigns) =~ """
+      html =~ """
       <div>
         <header>
           My Header
@@ -687,8 +687,8 @@ defmodule Surface.SlotTest do
       """
     )
 
-    code =
-      quote do
+    html =
+      render_surface do
         ~H"""
         <OuterWithOptionalNamedSlot>
           My Content
@@ -697,7 +697,7 @@ defmodule Surface.SlotTest do
       end
 
     assert_html(
-      render_live(code, assigns) =~ """
+      html =~ """
       <div>
         <main>
           My Content

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,7 @@ defmodule Surface.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import Phoenix.LiveViewTest
+      import Phoenix.LiveView.Helpers, only: [live_component: 3, live_component: 4]
       import Surface, only: [sigil_H: 2]
       import Surface.LiveViewTest
       import Surface.ConnCase

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,0 +1,30 @@
+defmodule Surface.ConnCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+
+  It also imports other functionality to make it easier
+  to test components.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with connections
+      import Plug.Conn
+      import Phoenix.ConnTest
+      import Phoenix.LiveViewTest
+      import Surface, only: [sigil_H: 2]
+      import Surface.LiveViewTest
+      import Surface.ConnCase
+
+      # The default endpoint for testing
+      @endpoint Endpoint
+    end
+  end
+
+  setup _tags do
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -12,13 +12,8 @@ defmodule Surface.ConnCase do
   using do
     quote do
       # Import conveniences for testing with connections
-      import Plug.Conn
       import Phoenix.ConnTest
-      import Phoenix.LiveViewTest
-      import Phoenix.LiveView.Helpers, only: [live_component: 3, live_component: 4]
-      import Surface, only: [sigil_H: 2]
-      import Surface.LiveViewTest
-      import Surface.ConnCase
+      use Surface.LiveViewTest
 
       # The default endpoint for testing
       @endpoint Endpoint

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -11,8 +11,7 @@ defmodule Surface.ConnCase do
 
   using do
     quote do
-      # Import conveniences for testing with connections
-      import Phoenix.ConnTest
+      # Import conveniences for testing
       use Surface.LiveViewTest
 
       # The default endpoint for testing

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -46,13 +46,6 @@ defmodule ComponentTestHelper do
     end
   end
 
-  def render_live(module, assigns, _env) when is_atom(module) do
-    conn = Phoenix.ConnTest.build_conn()
-    {:ok, _view, html} = Phoenix.LiveViewTest.live_isolated(conn, module, session: assigns)
-
-    clean_html(html)
-  end
-
   defmacro render_live(code, assigns \\ quote(do: %{})) do
     quote do
       render_live(unquote(code), unquote(assigns), unquote(Macro.escape(__CALLER__)))

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -111,26 +111,13 @@ defmodule ComponentTestHelper do
       value = unquote(config)
       new_config = Keyword.update(old_config, component, value, fn _ -> value end)
       Application.put_env(:surface, :components, new_config)
-      recompile(component)
 
       try do
         unquote(block)
       after
         Application.put_env(:surface, :components, old_config)
-        recompile(component)
       end
     end
-  end
-
-  def recompile(module) do
-    ExUnit.CaptureIO.capture_io(:standard_error, fn ->
-      module.module_info(:compile)
-      |> Keyword.fetch!(:source)
-      |> to_string()
-      |> Code.compile_file()
-    end)
-
-    :ok
   end
 
   defp clean_html(html) do


### PR DESCRIPTION
This PR addresses something that has been bothering me for a while which is the amount of tests we have that depends on `render_live/2`. The problem with `render_live/2` is that it creates a module (LiveView) on the fly for each test, consequently, it's very slow and it's making the test suite take much longer than is should. Just to give you an idea of the problem, currently, the tests for the form controls alone are consuming 60% of the time when running the whole suite.

In general, from now on, `render_live/2` should be used sparingly and only for tests that requires either a parent LiveView or some complex interaction between components, e.g. testing events, changing state, etc. Unfortunately, we couldn't use phoenix's built-in `render_component/3` because surface components require some additional setup.

This PR introduces a new `render_surface_component/3` that should be used for most of the cases we have when testing stateless components (like form controls) as well as when testing live component's rendering (not events and their side effects).

After this PR is merged, I'll start migrating most of the tests to use the new function. Since we have lots of tests in this situation, any help with that task will be appreciated. I'll also review what we have in `test_helper.exs` and maybe remove some functions or move them to the new `Surface.LiveViewTest` module. This way those functions can be used by other users in their own tests.

@Malian, @miguel-s and @alexandrubagu since you implemented most of the existing form controls, I'd love to hear your thoughts on this one. Does any of you see any problem with this new approach?