### PR TITLE
Replace render_live and render_static with render_surface

### DIFF
--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -30,6 +30,55 @@ defmodule Surface.LiveViewTest do
   end
 
   @doc """
+  Render Surface code containing only HTML markup + interpolation.
+
+  This function is the preferred way to test Surface code that doesn't include components
+  as it's much faster than `render_surface/1`.
+
+  Any directive or syntactic sugar for attributes will be evaluated. If the code contains
+  any component, please use `render_surface/1` instead.
+
+  ## Example
+
+      html =
+        render_surface_markup do
+          ~H"\""
+          <button :on-click="ok">OK</button>
+          "\""
+        end
+
+      assert html =~ "\""
+             <button phx-click="ok">OK</button>
+             "\""
+
+  """
+  defmacro render_surface_markup(do: do_block) do
+    render_call =
+      quote do
+        unquote(__MODULE__).__render_surface_markup__(unquote(do_block))
+      end
+
+    if Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do
+      quote do
+        unquote(render_call)
+      end
+    else
+      quote do
+        var!(assigns) = %{}
+        unquote(render_call)
+      end
+    end
+  end
+
+  @doc false
+  def __render_surface_markup__(code) do
+    code
+    |> Phoenix.HTML.Safe.to_iodata()
+    |> IO.iodata_to_binary()
+    |> String.replace(~r/\n+/, "\n")
+  end
+
+  @doc """
   Render Surface code.
 
   Use this macro when testing regular rendering of stateless components or live components
@@ -126,16 +175,16 @@ defmodule Surface.LiveViewTest do
 
   ## Example
 
-    using_config TextInput, default_class: "default_class" do
-      html =
-        render_surface do
-          ~H"\""
-          <TextInput/>
-          "\""
-        end
+      using_config TextInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~H"\""
+            <TextInput/>
+            "\""
+          end
 
-      assert html =~ ~r/class="default_class"/
-    end
+        assert html =~ ~r/class="default_class"/
+      end
 
   """
   defmacro using_config(component, config, do: block) do

--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -30,55 +30,6 @@ defmodule Surface.LiveViewTest do
   end
 
   @doc """
-  Render Surface code containing only HTML markup + interpolation.
-
-  This function is the preferred way to test Surface code that doesn't include components
-  as it's much faster than `render_surface/1`.
-
-  Any directive or syntactic sugar for attributes will be evaluated. If the code contains
-  any component, please use `render_surface/1` instead.
-
-  ## Example
-
-      html =
-        render_surface_markup do
-          ~H"\""
-          <button :on-click="ok">OK</button>
-          "\""
-        end
-
-      assert html =~ "\""
-             <button phx-click="ok">OK</button>
-             "\""
-
-  """
-  defmacro render_surface_markup(do: do_block) do
-    render_call =
-      quote do
-        unquote(__MODULE__).__render_surface_markup__(unquote(do_block))
-      end
-
-    if Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do
-      quote do
-        unquote(render_call)
-      end
-    else
-      quote do
-        var!(assigns) = %{}
-        unquote(render_call)
-      end
-    end
-  end
-
-  @doc false
-  def __render_surface_markup__(code) do
-    code
-    |> Phoenix.HTML.Safe.to_iodata()
-    |> IO.iodata_to_binary()
-    |> String.replace(~r/\n+/, "\n")
-  end
-
-  @doc """
   Render Surface code.
 
   Use this macro when testing regular rendering of stateless components or live components

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -118,7 +118,7 @@ defmodule Surface.DirectivesTest do
   describe ":attrs in html tags" do
     test "passing a keyword list" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div class="myclass" :attrs={{ id: "myid" }}>
             Some Text
@@ -135,7 +135,7 @@ defmodule Surface.DirectivesTest do
 
     test "passing a map" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div class="myclass" :attrs={{ %{id: "myid"} }}>
             Some Text
@@ -154,7 +154,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{div_props: [id: "myid", "aria-label": "A div"]}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div class="myclass" :attrs={{ @div_props }}>
             Some Text
@@ -171,7 +171,7 @@ defmodule Surface.DirectivesTest do
 
     test "with boolean properties" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div class="myclass" :attrs={{ disabled: true }}>
             Some Text
@@ -188,7 +188,7 @@ defmodule Surface.DirectivesTest do
 
     test "static properties override dyanmic properties" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div class="myclass" id="static-id" :attrs={{ id: "dynamic-id" }}>
             Some Text
@@ -209,7 +209,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{items: [:a, :b]}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div :for.index.with_index={{ {i, j} <- @items }}>
             i: {{ i }}, j: {{ j }}
@@ -320,7 +320,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{items: [1, 2]}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div :for={{ i <- @items }}>
             Item: {{i}}
@@ -339,7 +339,7 @@ defmodule Surface.DirectivesTest do
 
     test "in void html elements" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <br :for={{ _ <- [1,2] }}>
           """
@@ -373,7 +373,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{items1: [1, 2], items2: [3, 4]}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div :for={{ i1 <- @items1, i2 <- @items2, i1 < 4 }}>
             Item1: {{i1}}
@@ -406,7 +406,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{items: [1, 2]}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div :for.with_index={{ {item, index} <- @items }}>
             Item: {{ item }}, Index: {{ index }}
@@ -427,7 +427,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{items: [1, 2]}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div :for.index={{ index <- @items }}>
             Index: {{ index }}
@@ -448,7 +448,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{items: [1, 2]}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div :for.index={{ @items }}>
             Index: {{ index }}
@@ -493,7 +493,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{show: true, dont_show: false}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <div :if={{ @show }}>
             Show
@@ -515,7 +515,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{show: true, dont_show: false}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <col class="show" :if={{ @show }}>
           <col class="dont_show" :if={{ @dont_show }}>
@@ -567,7 +567,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{show: true}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <col style="padding: 1px;" :show={{ @show }}>
           <col :show=true>
@@ -584,7 +584,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{show: false}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <col style="padding: 1px;" :show={{ @show }}>
           """
@@ -599,7 +599,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{show: false}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <col :show={{ @show }}>
           """
@@ -616,7 +616,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{click: %{name: "ok", target: "#comp"}}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <button :on-click={{ @click }}>OK</button>
           """
@@ -631,7 +631,7 @@ defmodule Surface.DirectivesTest do
       assigns = %{click: "ok"}
 
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <button :on-click={{ @click }}>OK</button>
           """
@@ -644,7 +644,7 @@ defmodule Surface.DirectivesTest do
 
     test "as a literal string" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <button :on-click="ok">OK</button>
           """
@@ -657,7 +657,7 @@ defmodule Surface.DirectivesTest do
 
     test "as event name + target option" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <button :on-click={{ "ok", target: "#comp" }}>OK</button>
           """
@@ -670,7 +670,7 @@ defmodule Surface.DirectivesTest do
 
     test "do not translate invalid events" do
       html =
-        render_surface_markup do
+        render_surface do
           ~H"""
           <button :on-invalid="ok">OK</button>
           """

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -1,8 +1,5 @@
 defmodule Surface.DirectivesTest do
-  use ExUnit.Case, async: true
-
-  import Surface
-  import ComponentTestHelper
+  use Surface.ConnCase, async: true
 
   defmodule Div do
     use Surface.Component
@@ -71,16 +68,14 @@ defmodule Surface.DirectivesTest do
 
   describe ":props for a component" do
     test "passing keyword list of props" do
-      assigns = %{}
-
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <DivWithProps :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div class="text-xs block">
                dynamic props content
              </div>
@@ -88,16 +83,14 @@ defmodule Surface.DirectivesTest do
     end
 
     test "static props override dynamic props" do
-      assigns = %{}
-
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <DivWithProps content="static content" :props={{ class: "text-xs", hidden: false, content: "dynamic props content" }} />
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div class="text-xs block">
                static content
              </div>
@@ -107,14 +100,14 @@ defmodule Surface.DirectivesTest do
     test "using an assign" do
       assigns = %{opts: %{class: "text-xs", hidden: false, content: "dynamic props content"}}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <DivWithProps :props={{ @opts }} />
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div class="text-xs block">
                dynamic props content
              </div>
@@ -124,15 +117,16 @@ defmodule Surface.DirectivesTest do
 
   describe ":attrs in html tags" do
     test "passing a keyword list" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <div class="myclass" :attrs={{ id: "myid" }}>
+            Some Text
+          </div>
+          """
+        end
 
-      code = ~H"""
-      <div class="myclass" :attrs={{ id: "myid" }}>
-        Some Text
-      </div>
-      """
-
-      assert render_static(code) =~ """
+      assert html =~ """
              <div id="myid" class="myclass">
                Some Text
              </div>
@@ -140,15 +134,16 @@ defmodule Surface.DirectivesTest do
     end
 
     test "passing a map" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <div class="myclass" :attrs={{ %{id: "myid"} }}>
+            Some Text
+          </div>
+          """
+        end
 
-      code = ~H"""
-      <div class="myclass" :attrs={{ %{id: "myid"} }}>
-        Some Text
-      </div>
-      """
-
-      assert render_static(code) =~ """
+      assert html =~ """
              <div id="myid" class="myclass">
                Some Text
              </div>
@@ -158,13 +153,16 @@ defmodule Surface.DirectivesTest do
     test "using an assign" do
       assigns = %{div_props: [id: "myid", "aria-label": "A div"]}
 
-      code = ~H"""
-      <div class="myclass" :attrs={{ @div_props }}>
-        Some Text
-      </div>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <div class="myclass" :attrs={{ @div_props }}>
+            Some Text
+          </div>
+          """
+        end
 
-      assert render_static(code) =~ """
+      assert html =~ """
              <div aria-label="A div" id="myid" class="myclass">
                Some Text
              </div>
@@ -172,15 +170,16 @@ defmodule Surface.DirectivesTest do
     end
 
     test "with boolean properties" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <div class="myclass" :attrs={{ disabled: true }}>
+            Some Text
+          </div>
+          """
+        end
 
-      code = ~H"""
-      <div class="myclass" :attrs={{ disabled: true }}>
-        Some Text
-      </div>
-      """
-
-      assert render_static(code) =~ """
+      assert html =~ """
              <div disabled class="myclass">
                Some Text
              </div>
@@ -188,15 +187,16 @@ defmodule Surface.DirectivesTest do
     end
 
     test "static properties override dyanmic properties" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <div class="myclass" id="static-id" :attrs={{ id: "dynamic-id" }}>
+            Some Text
+          </div>
+          """
+        end
 
-      code = ~H"""
-      <div class="myclass" id="static-id" :attrs={{ id: "dynamic-id" }}>
-        Some Text
-      </div>
-      """
-
-      assert render_static(code) =~ """
+      assert html =~ """
              <div class="myclass" id="static-id">
                Some Text
              </div>
@@ -208,8 +208,8 @@ defmodule Surface.DirectivesTest do
     test "using multiple modifiers" do
       assigns = %{items: [:a, :b]}
 
-      code =
-        quote do
+      html =
+        render_surface_markup do
           ~H"""
           <div :for.index.with_index={{ {i, j} <- @items }}>
             i: {{ i }}, j: {{ j }}
@@ -217,7 +217,7 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                i: 0, j: 0
              </div><div>
@@ -229,8 +229,8 @@ defmodule Surface.DirectivesTest do
     test "modifiers on components" do
       assigns = %{items: [1, 2]}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <Div :for.with_index={{ {iii, index} <- @items }}>
             Item: {{ iii }}, Index: {{ index }}
@@ -238,10 +238,11 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                Item: 1, Index: 0
-             </div><div>
+             </div>
+             <div>
                Item: 2, Index: 1
              </div>
              """
@@ -265,7 +266,7 @@ defmodule Surface.DirectivesTest do
       """
 
       assert_raise(CompileError, message, fn ->
-        render_live(code, assigns)
+        compile_surface(code, assigns)
       end)
     end
 
@@ -287,7 +288,7 @@ defmodule Surface.DirectivesTest do
       """
 
       assert_raise(CompileError, message, fn ->
-        render_live(code, assigns)
+        compile_surface(code, assigns)
       end)
     end
   end
@@ -296,8 +297,8 @@ defmodule Surface.DirectivesTest do
     test "in components" do
       assigns = %{items: [1, 2]}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <Div :for={{ i <- @items }}>
             Item: {{i}}
@@ -305,10 +306,11 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                Item: 1
-             </div><div>
+             </div>
+             <div>
                Item: 2
              </div>
              """
@@ -317,8 +319,8 @@ defmodule Surface.DirectivesTest do
     test "in html tags" do
       assigns = %{items: [1, 2]}
 
-      code =
-        quote do
+      html =
+        render_surface_markup do
           ~H"""
           <div :for={{ i <- @items }}>
             Item: {{i}}
@@ -326,7 +328,7 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                Item: 1
              </div><div>
@@ -336,20 +338,21 @@ defmodule Surface.DirectivesTest do
     end
 
     test "in void html elements" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <br :for={{ _ <- [1,2] }}>
+          """
+        end
 
-      code = ~H"""
-      <br :for={{ _ <- [1,2] }}>
-      """
-
-      assert render_static(code) == """
+      assert html == """
              <br><br>
              """
     end
 
     test "in slots" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <DivWithSlotUsingFor repeat=3>
             <span>surface</span>
@@ -357,16 +360,20 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code) == """
-             <div><span>surface</span><span>surface</span><span>surface</span></div>
+      assert html == """
+             <div>
+               <span>surface</span>
+               <span>surface</span>
+               <span>surface</span>
+             </div>
              """
     end
 
     test "with larger generator expression" do
       assigns = %{items1: [1, 2], items2: [3, 4]}
 
-      code =
-        quote do
+      html =
+        render_surface_markup do
           ~H"""
           <div :for={{ i1 <- @items1, i2 <- @items2, i1 < 4 }}>
             Item1: {{i1}}
@@ -375,7 +382,7 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                Item1: 1
                Item2: 3
@@ -398,8 +405,8 @@ defmodule Surface.DirectivesTest do
     test "with_index modifier" do
       assigns = %{items: [1, 2]}
 
-      code =
-        quote do
+      html =
+        render_surface_markup do
           ~H"""
           <div :for.with_index={{ {item, index} <- @items }}>
             Item: {{ item }}, Index: {{ index }}
@@ -407,7 +414,7 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                Item: 1, Index: 0
              </div><div>
@@ -419,8 +426,8 @@ defmodule Surface.DirectivesTest do
     test "index modifier with generator" do
       assigns = %{items: [1, 2]}
 
-      code =
-        quote do
+      html =
+        render_surface_markup do
           ~H"""
           <div :for.index={{ index <- @items }}>
             Index: {{ index }}
@@ -428,7 +435,7 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                Index: 0
              </div><div>
@@ -440,8 +447,8 @@ defmodule Surface.DirectivesTest do
     test "index modifier with list" do
       assigns = %{items: [1, 2]}
 
-      code =
-        quote do
+      html =
+        render_surface_markup do
           ~H"""
           <div :for.index={{ @items }}>
             Index: {{ index }}
@@ -449,7 +456,7 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) =~ """
+      assert html =~ """
              <div>
                Index: 0
              </div><div>
@@ -463,8 +470,8 @@ defmodule Surface.DirectivesTest do
     test "in components" do
       assigns = %{show: true, dont_show: false}
 
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <Div :if={{ @show }}>
             Show
@@ -475,7 +482,7 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code, assigns) == """
+      assert html == """
              <div>
                Show
              </div>
@@ -485,16 +492,19 @@ defmodule Surface.DirectivesTest do
     test "in html tags" do
       assigns = %{show: true, dont_show: false}
 
-      code = ~H"""
-      <div :if={{ @show }}>
-        Show
-      </div>
-      <div :if={{ @dont_show }}>
-        Dont's show
-      </div>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <div :if={{ @show }}>
+            Show
+          </div>
+          <div :if={{ @dont_show }}>
+            Dont's show
+          </div>
+          """
+        end
 
-      assert render_static(code) =~ """
+      assert html =~ """
              <div>
                Show
              </div>
@@ -504,19 +514,22 @@ defmodule Surface.DirectivesTest do
     test "in void html elements" do
       assigns = %{show: true, dont_show: false}
 
-      code = ~H"""
-      <col class="show" :if={{ @show }}>
-      <col class="dont_show" :if={{ @dont_show }}>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <col class="show" :if={{ @show }}>
+          <col class="dont_show" :if={{ @dont_show }}>
+          """
+        end
 
-      assert render_static(code) == """
+      assert html == """
              <col class="show">
              """
     end
 
     test "in slots" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <DivWithSlotUsingIf show=true>1</DivWithSlotUsingIf>
           <DivWithSlotUsingIf show=false>2</DivWithSlotUsingIf>
@@ -524,14 +537,16 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code) == """
-             <div>1</div><div></div><div>3</div>
+      assert html == """
+             <div>1</div>
+             <div></div>
+             <div>3</div>
              """
     end
 
     test "in slots with props" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <DivWithSlotUsingIfAndProps show=true :let={{ data: d }}>1 - {{ d }}</DivWithSlotUsingIfAndProps>
           <DivWithSlotUsingIfAndProps show=false :let={{ data: d }}>2 - {{ d }}</DivWithSlotUsingIfAndProps>
@@ -539,8 +554,10 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      assert render_live(code) == """
-             <div>1 - data</div><div></div><div>3 - data</div>
+      assert html == """
+             <div>1 - data</div>
+             <div></div>
+             <div>3 - data</div>
              """
     end
   end
@@ -549,12 +566,15 @@ defmodule Surface.DirectivesTest do
     test "when true, do nothing" do
       assigns = %{show: true}
 
-      code = ~H"""
-      <col style="padding: 1px;" :show={{ @show }}>
-      <col :show=true>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <col style="padding: 1px;" :show={{ @show }}>
+          <col :show=true>
+          """
+        end
 
-      assert render_static(code) == """
+      assert html == """
              <col style="padding: 1px">
              <col>
              """
@@ -563,11 +583,14 @@ defmodule Surface.DirectivesTest do
     test "when false and style already exists, add `display: none`" do
       assigns = %{show: false}
 
-      code = ~H"""
-      <col style="padding: 1px;" :show={{ @show }}>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <col style="padding: 1px;" :show={{ @show }}>
+          """
+        end
 
-      assert render_static(code) == """
+      assert html == """
              <col style="display: none; padding: 1px">
              """
     end
@@ -575,11 +598,14 @@ defmodule Surface.DirectivesTest do
     test "when false and style does not exists, create style and add `display: none`" do
       assigns = %{show: false}
 
-      code = ~H"""
-      <col :show={{ @show }}>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <col :show={{ @show }}>
+          """
+        end
 
-      assert render_static(code) == """
+      assert html == """
              <col style="display: none">
              """
     end
@@ -589,11 +615,14 @@ defmodule Surface.DirectivesTest do
     test "as an event map" do
       assigns = %{click: %{name: "ok", target: "#comp"}}
 
-      code = ~H"""
-      <button :on-click={{ @click }}>OK</button>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <button :on-click={{ @click }}>OK</button>
+          """
+        end
 
-      assert render_static(code) =~ """
+      assert html =~ """
              <button phx-click="ok" phx-target="#comp">OK</button>
              """
     end
@@ -601,47 +630,53 @@ defmodule Surface.DirectivesTest do
     test "as a string" do
       assigns = %{click: "ok"}
 
-      code = ~H"""
-      <button :on-click={{ @click }}>OK</button>
-      """
+      html =
+        render_surface_markup do
+          ~H"""
+          <button :on-click={{ @click }}>OK</button>
+          """
+        end
 
-      assert render_static(code) =~ """
+      assert html =~ """
              <button phx-click="ok">OK</button>
              """
     end
 
     test "as a literal string" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <button :on-click="ok">OK</button>
+          """
+        end
 
-      code = ~H"""
-      <button :on-click="ok">OK</button>
-      """
-
-      assert render_static(code) =~ """
+      assert html =~ """
              <button phx-click="ok">OK</button>
              """
     end
 
     test "as event name + target option" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <button :on-click={{ "ok", target: "#comp" }}>OK</button>
+          """
+        end
 
-      code = ~H"""
-      <button :on-click={{ "ok", target: "#comp" }}>OK</button>
-      """
-
-      assert render_static(code) =~ """
+      assert html =~ """
              <button phx-click="ok" phx-target="#comp">OK</button>
              """
     end
 
     test "do not translate invalid events" do
-      assigns = %{}
+      html =
+        render_surface_markup do
+          ~H"""
+          <button :on-invalid="ok">OK</button>
+          """
+        end
 
-      code = ~H"""
-      <button :on-invalid="ok">OK</button>
-      """
-
-      assert render_static(code) =~ """
+      assert html =~ """
              <button :on-invalid="ok">OK</button>
              """
     end
@@ -649,12 +684,11 @@ defmodule Surface.DirectivesTest do
 end
 
 defmodule Surface.DirectivesSyncTest do
-  use ExUnit.Case
+  use Surface.ConnCase
 
   import ExUnit.CaptureIO
-  import ComponentTestHelper
 
-  alias Surface.DirectivesTest.{DivWithProps}, warn: false
+  alias Surface.DirectivesTest.{DivWithProps}
 
   describe ":props on a component" do
     test "emits a warning with an unknown prop at runtime" do
@@ -667,37 +701,16 @@ defmodule Surface.DirectivesSyncTest do
         }
       }
 
-      code =
-        quote do
-          ~H"""
-          <DivWithProps :props={{ @opts }} />
-          """
-        end
+      message =
+        capture_io(:standard_error, fn ->
+          render_surface do
+            ~H"""
+            <DivWithProps :props={{ @opts }} />
+            """
+          end
+        end)
 
-      {:warn, message} = capture_warning(code, assigns)
-
-      assert message =~ "Unknown property \"unknown\" for component <DivWithProps>"
-    end
-  end
-
-  defp capture_warning(code, assigns) do
-    output =
-      capture_io(:standard_error, fn ->
-        result = render_live(code, assigns)
-        send(self(), {:result, result})
-      end)
-
-    result =
-      receive do
-        {:result, result} -> result
-      end
-
-    case output do
-      "" ->
-        {:ok, result}
-
-      message ->
-        {:warn, message}
+      assert message =~ ~S|Unknown property "unknown" for component <DivWithProps>|
     end
   end
 end


### PR DESCRIPTION
This is the last function planned for the new test API and replaces the existing `render_static`. It should be used for any surface code containing only HTML markup + interpolation (no components). Here's the updated list, from the fastest to slowest:

  1. ~`render_surface_markup/1` - Test Surface code containing only HTML markup + interpolation (no components).~

  1. `render_surface/1`-  Test surface markup code, stateless components or the regular rendering of a live component.

  1. `compile_surface/2` - Test compile-time errors/warnings. 

  1. `compile_surface/2` (or inline module) + `Phoenix.LiveViewTest.live_isolated/3` - Test all other cases where a test-specific LiveView is required, i.e, you'll not share the LV between tests. Otherwise, it's better to define the module inline and use it in various tests, if possible.

