### PR TITLE
Migrate component_test file, and construct for and if test files

### DIFF
--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.ComponentTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
@@ -228,21 +228,23 @@ defmodule Surface.ComponentTest do
 
   describe "Without LiveView" do
     test "render stateless component" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <Stateless label="My label" class="myclass"/>
           """
         end
 
-      assert render_live(code) =~ """
-             <div class="myclass"><span>My label</span></div>
-             """
+      assert_html(
+        html =~ """
+        <div class="myclass"><span>My label</span></div>
+        """
+      )
     end
 
     test "render nested component's content" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <Outer>
             <Inner/>
@@ -250,14 +252,16 @@ defmodule Surface.ComponentTest do
           """
         end
 
-      assert render_live(code) =~ """
-             <div><span>Inner</span></div>
-             """
+      assert_html(
+        html =~ """
+        <div><span>Inner</span></div>
+        """
+      )
     end
 
     test "render content with slot props" do
-      code =
-        quote do
+      html =
+        render_surface do
           ~H"""
           <OuterWithSlotProps :let={{ info: my_info }}>
             {{ my_info }}
@@ -265,11 +269,13 @@ defmodule Surface.ComponentTest do
           """
         end
 
-      assert render_live(code) =~ """
-             <div>
-               My info
-             </div>
-             """
+      assert_html(
+        html =~ """
+        <div>
+          My info
+        </div>
+        """
+      )
     end
 
     test "render stateless component without named slots with render_component/2" do

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.Constructs.ForTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
   import ComponentTestHelper
 
@@ -17,8 +17,10 @@ defmodule Surface.Constructs.ForTest do
   end
 
   test "iterates over the provided list" do
-    code =
-      quote do
+    alias Surface.Constructs.For
+
+    html =
+      render_surface do
         ~H"""
         <For each={{ fruit <- ["apples", "bananas", "oranges"] }}>
         <span>{{ fruit }}</span>
@@ -26,11 +28,13 @@ defmodule Surface.Constructs.ForTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <span>apples</span>\
-           <span>bananas</span>\
-           <span>oranges</span>
-           """
+    assert_html(
+      html =~ """
+      <span>apples</span>\
+      <span>bananas</span>\
+      <span>oranges</span>
+      """
+    )
   end
 
   test "parser error message contains the correct line" do

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.Constructs.IfTest do
-  use ExUnit.Case, async: true
+  use Surface.ConnCase, async: true
 
   import ComponentTestHelper
 
@@ -17,8 +17,10 @@ defmodule Surface.Constructs.IfTest do
   end
 
   test "renders inner if condition is truthy" do
-    code =
-      quote do
+    alias Surface.Constructs.If
+
+    html =
+      render_surface do
         ~H"""
         <If condition={{ true }}>
         <span>The inner content</span>
@@ -27,10 +29,12 @@ defmodule Surface.Constructs.IfTest do
         """
       end
 
-    assert render_live(code) =~ """
-           <span>The inner content</span>\
-           <span>with multiple tags</span>
-           """
+    assert_html(
+      html =~ """
+      <span>The inner content</span>\
+      <span>with multiple tags</span>
+      """
+    )
   end
 
   test "parser error message contains the correct line" do


### PR DESCRIPTION
As @miguel-s is working on form components in #233 I tackle components outside that scope.

@msaraiva I had to alias `If` and `For` constructs to be able to use `render_surface` macro in tests. As these are also components I am not sure it's the right way to do or if we should modify something in the `render_surface` macro to automatically load these constructs.

