### PR TITLE
Raises compile error if slots are not declared

### DIFF
--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -52,7 +52,6 @@ defmodule Surface.API do
 
       for func <- unquote(include) do
         Module.register_attribute(__MODULE__, func, accumulate: true)
-        unquote(__MODULE__).init_func(func, __MODULE__)
       end
     end
   end
@@ -72,16 +71,6 @@ defmodule Surface.API do
     if function_exported?(env.module, :__slots__, 0) do
       validate_slot_props_bindings!(env)
     end
-  end
-
-  @doc false
-  def init_func(:slot, module) do
-    Module.register_attribute(module, :used_slot, accumulate: true)
-    :ok
-  end
-
-  def init_func(_func, _caller) do
-    :ok
   end
 
   @doc "Defines a property for the component"
@@ -167,12 +156,7 @@ defmodule Surface.API do
 
   @doc false
   def get_slots(module) do
-    used_slots =
-      for %{name: name, line: line} <- Module.get_attribute(module, :used_slot) || [] do
-        %{func: :slot, name: name, type: :any, doc: nil, opts: [], opts_ast: [], line: line}
-      end
-
-    (Module.get_attribute(module, :slot) || []) ++ used_slots
+    Module.get_attribute(module, :slot) || []
   end
 
   @doc false

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -748,9 +748,11 @@ defmodule Surface.Compiler do
       if component_slotable?(template_meta.module) do
         """
         The slotable component <#{template_meta.module}> as the `:slot` option set to \
-        `#{slot_name}`.\n
-        That slot name is not declared in parent component <#{parent_meta.node_alias}>.\n
-        Please declare the slot in the parent component or rename the value in the `:slot` option.
+        `#{slot_name}`.
+
+        That slot name is not declared in parent component <#{parent_meta.node_alias}>.
+
+        Please declare the slot in the parent component or rename the value in the `:slot` option.\
         """
       else
         """

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -444,12 +444,8 @@ defmodule Surface.Compiler do
 
   defp has_attribute?([], _), do: false
 
-  defp has_attribute?(attributes, attr_name) do
-    Enum.find_value(attributes, false, fn
-      {^attr_name, _, _} -> true
-      _ -> nil
-    end)
-  end
+  defp has_attribute?(attributes, attr_name),
+    do: Enum.any?(attributes, &match?({^attr_name, _, _}, &1))
 
   defp attribute_value_as_ast(attributes, attr_name, default, meta) do
     Enum.find_value(attributes, default, fn

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -727,8 +727,9 @@ defmodule Surface.Compiler do
          true = _short_syntax?
        ) do
     message = """
-    no slot `#{slot_name}` defined in the component `#{inspect(module)}`\
-    \n\nPlease declare the default slot using `slot default` in order to use the `<slot />` notation.
+    no slot `#{slot_name}` defined in the component `#{inspect(module)}`
+
+    Please declare the default slot using `slot default` in order to use the `<slot />` notation.
     """
 
     IOHelper.compile_error(message, meta.file, meta.line)

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -655,10 +655,7 @@ defmodule Surface.Compiler do
   end
 
   defp validate_templates(mod, templates, meta) do
-    names =
-      templates
-      |> Map.keys()
-      |> Enum.reject(fn name -> name == :default end)
+    names = templates |> Map.keys()
 
     if !function_exported?(mod, :__slots__, 0) and not Enum.empty?(names) do
       message = """

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -744,8 +744,22 @@ defmodule Surface.Compiler do
 
     existing_slots_message = existing_slots_message(parent_slots)
 
+    header_message =
+      if component_slotable?(template_meta.module) do
+        """
+        The slotable component <#{template_meta.module}> as the `:slot` option set to \
+        `#{slot_name}`.\n
+        That slot name is not declared in parent component <#{parent_meta.node_alias}>.\n
+        Please declare the slot in the parent component or rename the value in the `:slot` option.
+        """
+      else
+        """
+        no slot "#{slot_name}" defined in parent component <#{parent_meta.node_alias}>\
+        """
+      end
+
     message = """
-    no slot "#{slot_name}" defined in parent component <#{parent_meta.node_alias}>\
+    #{header_message}\
     #{similar_slot_message}\
     #{existing_slots_message}
     """

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -730,8 +730,8 @@ defmodule Surface.Compiler do
     no slot `#{slot_name}` defined in the component `#{module}`\
     #{similar_slot_message}\
     #{existing_slots_message}\
-    \n\nHint: You can define a new slot using the `slot` macro: \
-    `slot #{slot_name}`\
+    \n\nHint: You can define slots using the `slot` macro. \
+    \nFor instance: `slot #{slot_name}`\
     """
 
     IOHelper.compile_error(message, meta.file, meta.line)

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -731,7 +731,7 @@ defmodule Surface.Compiler do
          true = _short_syntax?
        ) do
     message = """
-    no slot `#{slot_name}` defined in the component `#{module}`\
+    no slot `#{slot_name}` defined in the component `#{inspect(module)}`\
     \n\nPlease declare the default slot using `slot default` in order to use the `<slot />` notation.
     """
 
@@ -750,11 +750,13 @@ defmodule Surface.Compiler do
     existing_slots_message = existing_slots_message(defined_slot_names)
 
     message = """
-    no slot `#{slot_name}` defined in the component `#{module}`\
+    no slot `#{slot_name}` defined in the component `#{inspect(module)}`\
     #{similar_slot_message}\
     #{existing_slots_message}\
-    \n\nHint: You can define slots using the `slot` macro. \
-    \nFor instance: `slot #{slot_name}`\
+
+    Hint: You can define slots using the `slot` macro.\
+
+    For instance: `slot #{slot_name}`\
     """
 
     IOHelper.compile_error(message, meta.file, meta.line)
@@ -770,7 +772,7 @@ defmodule Surface.Compiler do
     header_message =
       if component_slotable?(template_meta.module) do
         """
-        The slotable component <#{template_meta.module}> as the `:slot` option set to \
+        The slotable component <#{inspect(template_meta.module)}> as the `:slot` option set to \
         `#{slot_name}`.
 
         That slot name is not declared in parent component <#{parent_meta.node_alias}>.

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -653,7 +653,7 @@ defmodule Surface.Compiler do
   end
 
   defp validate_templates(mod, templates, meta) do
-    names = templates |> Map.keys()
+    names = Map.keys(templates)
 
     if !function_exported?(mod, :__slots__, 0) and not Enum.empty?(names) do
       message = """

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -692,19 +692,6 @@ defmodule Surface.Compiler do
           end
         end)
 
-      if slot == nil and not Enum.empty?(props) do
-        message = """
-        there's no `#{slot_name}` slot defined in `#{inspect(mod)}`.
-
-        Directive :let can only be used on explicitly defined slots.
-
-        Hint: You can define a `#{slot_name}` slot and its props using: \
-        `slot #{slot_name}, props: #{inspect(props)}\
-        """
-
-        IOHelper.compile_error(message, meta.file, meta.line)
-      end
-
       case slot do
         %{opts: opts} ->
           non_generator_args = Enum.map(opts[:props] || [], &Map.get(&1, :name))

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -18,6 +18,8 @@ defmodule Surface.CompilerTest do
   defmodule Div do
     use Surface.Component
 
+    slot default
+
     def render(assigns) do
       ~H"""
       <div><slot /></div>

--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -20,6 +20,8 @@ defmodule Surface.ComponentTest do
   defmodule Outer do
     use Surface.Component
 
+    slot default
+
     def render(assigns) do
       ~H"""
       <div><slot/></div>

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -55,7 +55,7 @@ defmodule Surface.Constructs.ForTest do
       quote do
         ~H"""
         <For each={{ fruit <- ["apples", "bananas", "oranges"] }}>
-          <ListProp prop="some string">The inner content</ListProp>
+          <ListProp prop="some string" />
         </For>
         """
       end

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -55,7 +55,7 @@ defmodule Surface.Constructs.IfTest do
       quote do
         ~H"""
         <If condition={{ true }}>
-          <ListProp prop="some string">The inner content</ListProp>
+          <ListProp prop="some string" />
         </If>
         """
       end

--- a/test/context_change_tracking_test.exs
+++ b/test/context_change_tracking_test.exs
@@ -9,6 +9,8 @@ defmodule Surface.ContextChangeTrackingTest do
   defmodule ContextSetter do
     use Surface.Component
 
+    slot default
+
     def render(assigns) do
       ~H"""
       <Context put={{ field: "field value" }}>
@@ -24,6 +26,8 @@ defmodule Surface.ContextChangeTrackingTest do
     alias Surface.CheckUpdated
 
     prop test_pid, :any, required: true
+
+    slot default
 
     def render(assigns) do
       ~H"""

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -6,6 +6,8 @@ defmodule ContextTest do
   defmodule Outer do
     use Surface.Component
 
+    slot default
+
     def render(assigns) do
       ~H"""
       <Context put={{ __MODULE__, field: "field from Outer" }}>
@@ -240,7 +242,7 @@ defmodule ContextTest do
           ~H"""
           <Context
             put={{ ContextTest.Outer, 123 }}>
-            <slot/>
+            Inner Content
           </Context>
           """
         end
@@ -263,7 +265,7 @@ defmodule ContextTest do
           ~H"""
           <Context
             put={{ ContextTest.Outer }}>
-            <slot/>
+            Inner content
           </Context>
           """
         end
@@ -279,7 +281,7 @@ defmodule ContextTest do
           ~H"""
           <Context
             put={{ 123, field: field }}>
-            <slot/>
+            Inner content
           </Context>
           """
         end

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -4,6 +4,8 @@ defmodule Surface.DirectivesTest do
   defmodule Div do
     use Surface.Component
 
+    slot default
+
     def render(assigns) do
       ~H"""
       <div><slot/></div>

--- a/test/live_component_test.exs
+++ b/test/live_component_test.exs
@@ -71,6 +71,8 @@ defmodule LiveComponentTest do
   defmodule InfoProviderWithoutSlotProps do
     use Surface.Component
 
+    slot default
+
     def render(assigns) do
       ~H"""
       <div>

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -784,9 +784,7 @@ defmodule Surface.SlotSyncTest do
     """
 
     assert_raise(CompileError, message, fn ->
-      capture_io(:standard_error, fn ->
-        compile_surface(code)
-      end)
+      compile_surface(code)
     end)
   end
 
@@ -835,9 +833,7 @@ defmodule Surface.SlotSyncTest do
     """
 
     assert_raise(CompileError, message, fn ->
-      capture_io(:standard_error, fn ->
-        compile_surface(code)
-      end)
+      compile_surface(code)
     end)
   end
 

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -845,7 +845,7 @@ defmodule Surface.SlotSyncTest do
     end)
   end
 
-  test "raises compile error on component that uses slots without declaring its" do
+  test "raises compile error on component that uses undeclared slots" do
     component_code = """
     defmodule TestComponentWithoutDeclaringSlots do
       use Surface.Component

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -780,7 +780,9 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = """
-    code:2: no slot "inner" defined in parent component <StatefulComponent>
+    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.\n
+    That slot name is not declared in parent component <StatefulComponent>.\n
+    Please declare the slot in the parent component or rename the value in the `:slot` option.\n
     """
 
     assert_raise(CompileError, message, fn ->
@@ -800,7 +802,9 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = """
-    code:2: no slot "inner" defined in parent component <Grid>
+    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.\n
+    That slot name is not declared in parent component <Grid>.\n
+    Please declare the slot in the parent component or rename the value in the `:slot` option.\n
 
     Available slot: "cols"
     """

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -780,7 +780,7 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = """
-    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.
+    code:2: The slotable component <Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.
 
     That slot name is not declared in parent component <StatefulComponent>.
 
@@ -804,7 +804,7 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = """
-    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.
+    code:2: The slotable component <Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.
 
     That slot name is not declared in parent component <Grid>.
 
@@ -866,11 +866,11 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:12: no slot `footer` defined in the component `Elixir.Surface.SlotSyncTest.TestComponentWithoutDeclaringSlots`
+    code:12: no slot `footer` defined in the component `Surface.SlotSyncTest.TestComponentWithoutDeclaringSlots`
 
-    Available slots: "default" and "header"
+    Available slots: "default" and "header"\
 
-    Hint: You can define slots using the `slot` macro. \
+    Hint: You can define slots using the `slot` macro.\
 
     For instance: `slot footer`\
     """
@@ -898,7 +898,7 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:7: no slot `default` defined in the component `Elixir.Surface.SlotSyncTest.TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot`
+    code:7: no slot `default` defined in the component `Surface.SlotSyncTest.TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot`
 
     Please declare the default slot using `slot default` in order to use the `<slot />` notation.
     """

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -802,9 +802,11 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = """
-    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.\n
-    That slot name is not declared in parent component <Grid>.\n
-    Please declare the slot in the parent component or rename the value in the `:slot` option.\n
+    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.
+
+    That slot name is not declared in parent component <Grid>.
+
+    Please declare the slot in the parent component or rename the value in the `:slot` option.
 
     Available slot: "cols"
     """

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -802,7 +802,7 @@ defmodule Surface.SlotSyncTest do
     message = """
     code:2: no slot "inner" defined in parent component <Grid>
 
-      Available slot: "cols"
+    Available slot: "cols"
     """
 
     assert_raise(CompileError, message, fn ->
@@ -827,9 +827,9 @@ defmodule Surface.SlotSyncTest do
     message = """
     code:4: no slot "foot" defined in parent component <OuterWithNamedSlot>
 
-      Did you mean "footer"?
+    Did you mean "footer"?
 
-      Available slots: "footer", "header" and "default"
+    Available slots: "footer", "header" and "default"
     """
 
     assert_raise(CompileError, message, fn ->
@@ -860,10 +860,38 @@ defmodule Surface.SlotSyncTest do
     message = ~r"""
     code:12: no slot `footer` defined in the component `Elixir.Surface.SlotSyncTest.TestComponentWithoutDeclaringSlots`
 
-    Available slots: default, header.
+    Available slots: "default" and "header"
 
     Hint: You can define a new slot using the `slot` macro: \
     `slot footer`\
+    """
+
+    assert_raise(CompileError, message, fn ->
+      capture_io(:standard_error, fn ->
+        Code.eval_string(component_code, [], %{__ENV__ | file: "code", line: 1})
+      end)
+    end)
+  end
+
+  test "raises compile error on component that uses short syntax <slot /> without declaring default slot" do
+    component_code = """
+    defmodule TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot do
+      use Surface.Component
+
+      def render(assigns) do
+        ~H"\""
+          <div>
+            <slot />
+          </div>
+        "\""
+      end
+    end
+    """
+
+    message = ~r"""
+    code:7: no slot `default` defined in the component `Elixir.Surface.SlotSyncTest.TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot`
+
+    Please declare the default slot using `slot default` in order to use the `<slot />` notation.
     """
 
     assert_raise(CompileError, message, fn ->

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -862,8 +862,9 @@ defmodule Surface.SlotSyncTest do
 
     Available slots: "default" and "header"
 
-    Hint: You can define a new slot using the `slot` macro: \
-    `slot footer`\
+    Hint: You can define slots using the `slot` macro. \
+
+    For instance: `slot footer`\
     """
 
     assert_raise(CompileError, message, fn ->

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -780,9 +780,11 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = """
-    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.\n
-    That slot name is not declared in parent component <StatefulComponent>.\n
-    Please declare the slot in the parent component or rename the value in the `:slot` option.\n
+    code:2: The slotable component <Elixir.Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.
+
+    That slot name is not declared in parent component <StatefulComponent>.
+
+    Please declare the slot in the parent component or rename the value in the `:slot` option.
     """
 
     assert_raise(CompileError, message, fn ->

--- a/test/transform_test.exs
+++ b/test/transform_test.exs
@@ -4,6 +4,8 @@ defmodule Surface.TransformTest do
   defmodule Span do
     use Surface.Component
 
+    slot default
+
     def render(assigns) do
       ~H"""
       <span><slot /></span>
@@ -13,6 +15,8 @@ defmodule Surface.TransformTest do
 
   defmodule DivToSpan do
     use Surface.Component
+
+    slot default
 
     @impl true
     def render(assigns) do
@@ -30,6 +34,8 @@ defmodule Surface.TransformTest do
 
   defmodule LiveDivToSpan do
     use Surface.LiveComponent
+
+    slot default
 
     @impl true
     def render(assigns) do
@@ -51,7 +57,7 @@ defmodule Surface.TransformTest do
     @impl true
     def render(assigns) do
       ~H"""
-      <div><slot /></div>
+      <div></div>
       """
     end
 
@@ -132,7 +138,7 @@ defmodule Surface.TransformTest do
 
   test "transform is run on compile when defined for Surface.LiveView" do
     code = """
-    <LiveDivViewToSpan id="view">Some content</LiveDivViewToSpan>
+    <LiveDivViewToSpan id="view" />
     """
 
     [node | _] = Surface.Compiler.compile(code, 1, __ENV__)


### PR DESCRIPTION
This pull request fixes #236 by making the declaring slots mandatory.

- [x] Raises error if slots are not declared in the parent component
- [x] Raises error if slots are not declared in current component with slot macro
- [x] Write better error messages:
  - [x] Some slots are defined, list them
  - [x] No slot is defined, show how to add a slot with the slot macro
  - [x] Short syntax used without declaring the default slot
  - [x] Slotable component
- [x] Refactoring
- [x] Look carefully for dead code

The following codes are not allowed any more:

### Forgetting to declare a named slot
```elixir
    defmodule MyComponent do
      use Surface.Component

      slot header
      slot default

      def render(assigns) do
        ~H"""
          <div>
            <slot name="header"/>
            <slot />
            <slot name="footer" />
          </div>
        """
      end
    end
```
### Forgetting to declare the `default` slot
```elixir
    defmodule MyComponent do
      use Surface.Component

      slot default

      def render(assigns) do
        ~H"""
          <div>
            <slot />
          </div>
        """
      end
    end
```
### Using a named slot that are not defined in the parent component
```elixir
    defmodule MyComponent do
      use Surface.Component

      slot default

      def render(assigns) do
        ~H"""
          <div>
            <slot />
          </div>
        """
      end
    end
    defmodule MyView do
      use Surface.LiveView

      alias MyComponent

      def render(assigns) do
        ~H"""
          <div>
             <MyComponent>
                <template name="header">
                   My Header
                </template>
             </MyComponent>
          </div>
        """
      end
    end
```
### Using the default slot without declaring it in the parent component
```elixir
    defmodule MyComponent do
      use Surface.Component

      slot default

      def render(assigns) do
        ~H"""
          <div>
            <slot />
          </div>
        """
      end
    end
    defmodule MyView do
      use Surface.LiveView

      alias MyComponent

      def render(assigns) do
        ~H"""
          <div>
             <MyComponent>
                My Content
             </MyComponent>
          </div>
        """
      end
    end
```

All these cases will raise a CompileError with proper messages.


