### PR TITLE
Remove default value from Form method prop

### DIFF
--- a/lib/surface/components/form.ex
+++ b/lib/surface/components/form.ex
@@ -26,8 +26,8 @@ defmodule Surface.Components.Form do
   @doc "The server side parameter in which all parameters will be gathered."
   prop as, :atom
 
-  @doc "Method to be used when submitting the form, default \"post\"."
-  prop method, :string, default: "post"
+  @doc "Method to be used when submitting the form."
+  prop method, :string
 
   @doc "When true, sets enctype to \"multipart/form-data\". Required when uploading files."
   prop multipart, :boolean, default: false

--- a/test/components/form_test.exs
+++ b/test/components/form_test.exs
@@ -149,7 +149,6 @@ defmodule Surface.Components.FormTest do
 
     {:ok, _view, html} = live_isolated(conn, ViewWithForm, session: assigns)
 
-    # assert html =~ ~s(<input name="_method" type="hidden" value="put" />)
     assert html =~ ~s(><input name="_method" type="hidden" value="put"/>)
   end
 end

--- a/test/components/form_test.exs
+++ b/test/components/form_test.exs
@@ -4,6 +4,14 @@ defmodule Surface.Components.FormTest do
   alias Surface.Components.Form
   alias Surface.Components.Form.TextInput
 
+  defmodule User do
+    use Ecto.Schema
+
+    schema "user" do
+      field(:name, :string)
+    end
+  end
+
   defmodule ViewWithForm do
     use Surface.LiveView
 
@@ -137,15 +145,12 @@ defmodule Surface.Components.FormTest do
   end
 
   test "form generates method input for changeset", %{conn: conn} do
-    assigns = %{
-      "changeset" =>
-        Ecto.Changeset.cast(
-          {%{}, %{name: :string}},
-          %{name: "myname"},
-          [:name]
-        )
-        |> Map.put(:data, %{__meta__: %{state: :loaded}})
-    }
+    changeset =
+      %User{}
+      |> Ecto.put_meta(state: :loaded)
+      |> Ecto.Changeset.cast(%{name: "myname"}, [:name])
+
+    assigns = %{"changeset" => changeset}
 
     {:ok, _view, html} = live_isolated(conn, ViewWithForm, session: assigns)
 

--- a/test/components/form_test.exs
+++ b/test/components/form_test.exs
@@ -123,4 +123,33 @@ defmodule Surface.Components.FormTest do
 
     assert html =~ ~r/Name is invalid/
   end
+
+  test "form generates method input for prop" do
+    html =
+      render_surface do
+        ~H"""
+        <Form for={{ :user }} action="#" method="put" csrf_token="test">
+        </Form>
+        """
+      end
+
+    assert html =~ ~s(<input name="_method" type="hidden" value="put">)
+  end
+
+  test "form generates method input for changeset", %{conn: conn} do
+    assigns = %{
+      "changeset" =>
+        Ecto.Changeset.cast(
+          {%{}, %{name: :string}},
+          %{name: "myname"},
+          [:name]
+        )
+        |> Map.put(:data, %{__meta__: %{state: :loaded}})
+    }
+
+    {:ok, _view, html} = live_isolated(conn, ViewWithForm, session: assigns)
+
+    # assert html =~ ~s(<input name="_method" type="hidden" value="put" />)
+    assert html =~ ~s(><input name="_method" type="hidden" value="put"/>)
+  end
 end


### PR DESCRIPTION
By having Surface set a default value for the `method` prop in the `Form` component we are forcing this value to always be "post" unless explicitly defined.

This causes issues with Phoenix's `form_for` e.g. automatically setting the method to "put" depending on the changeset.

Phoenix's `form_for` already has a default for it's `method` option, so I don't expect issues removing it from Surface.