### PR TITLE
Fix line offset when using single-line ~H variants

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -103,10 +103,8 @@ defmodule Surface do
   @doc """
   Translates Surface code into Phoenix templates.
   """
-  defmacro sigil_H({:<<>>, _, [string]}, opts) do
-    # This will create accurate line numbers for heredoc usages of the sigil, but
-    # not for ~H* variants. See https://github.com/msaraiva/surface/issues/15#issuecomment-667305899
-    line_offset = __CALLER__.line + 1
+  defmacro sigil_H({:<<>>, meta, [string]}, opts) do
+    line_offset = __CALLER__.line + compute_line_offset(meta)
 
     caller_is_surface_component =
       Module.open?(__CALLER__.module) &&
@@ -121,6 +119,18 @@ defmodule Surface do
       file: __CALLER__.file,
       line: __CALLER__.line
     )
+  end
+
+  defp compute_line_offset(meta) do
+    # Since `v1.10` this will create accurate line numbers for heredoc usages
+    # of the `~H` sigil. For version below `v1.10` single-line ~H will return
+    # an incorrect line number because there was no way to retrieve the information
+    # about the delimiter. See https://github.com/msaraiva/surface/issues/240
+    cond do
+      Keyword.has_key?(meta, :indentation) -> 1
+      not Version.match?(System.version(), "~> 1.10") -> 1
+      true -> 0
+    end
   end
 
   @doc "Retrieve a component's config based on the `key`"

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -122,13 +122,13 @@ defmodule Surface do
   end
 
   defp compute_line_offset(meta) do
-    # Since `v1.10` this will create accurate line numbers for heredoc usages
-    # of the `~H` sigil. For version below `v1.10` single-line ~H will return
+    # Since `v1.11` this will create accurate line numbers for heredoc usages
+    # of the `~H` sigil. For version below `v1.11` single-line ~H will return
     # an incorrect line number because there was no way to retrieve the information
     # about the delimiter. See https://github.com/msaraiva/surface/issues/240
     cond do
       Keyword.has_key?(meta, :indentation) -> 1
-      not Version.match?(System.version(), "~> 1.10") -> 1
+      not Version.match?(System.version(), "~> 1.11") -> 1
       true -> 0
     end
   end

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -803,7 +803,7 @@ defmodule Surface.CompilerSyncTest do
     """
 
     # See Surface.compute_line_offset/1 for more information
-    line_offset = if not Version.match?(System.version(), "~> 1.11"), do: 0, else: 1
+    line_offset = if Version.match?(System.version(), "~> 1.11"), do: 1, else: 0
 
     output =
       capture_io(:standard_error, fn ->

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -802,11 +802,14 @@ defmodule Surface.CompilerSyncTest do
     end\
     """
 
+    # See Surface.compute_line_offset/1 for more information
+    line_offset = if not Version.match?(System.version(), "~> 1.11"), do: 0, else: 1
+
     output =
       capture_io(:standard_error, fn ->
-        # Setting line to 0 here because we aren't using heredoc for the above code and so the lines would
-        # be off
-        {{:module, module, _, _}, _} = Code.eval_string(component_code, [], %{__ENV__ | line: 0})
+        {{:module, module, _, _}, _} =
+          Code.eval_string(component_code, [], %{__ENV__ | line: line_offset})
+
         send(self(), {:result, module})
       end)
 


### PR DESCRIPTION
Fixes #240 