### PR TITLE
Allow component children in link and label

### DIFF
--- a/lib/surface/components/form/label.ex
+++ b/lib/surface/components/form/label.ex
@@ -2,15 +2,15 @@ defmodule Surface.Components.Form.Label do
   @moduledoc """
   Defines a label.
 
-  Provides a wrapper for Phoenix.HTML.Form's `label/3` function.
+  Provides similar capabilities to Phoenix's built-in `label/3`
+  function.
 
-  All options passed via `opts` will be sent to `label/3`, `class` can
-  be set directly and will override anything in `opts`.
+  Option `class` can be set directly and will override anything in `opts`.
+  All other options are forwarded to the underlying <a> tag.
   """
 
   use Surface.Component
 
-  import Phoenix.HTML.Form, only: [label: 4]
   import Surface.Components.Form.Utils
   alias Surface.Components.Form.Input.InputContext
 
@@ -37,12 +37,16 @@ defmodule Surface.Components.Form.Label do
 
     ~H"""
     <InputContext assigns={{ assigns }} :let={{ form: form, field: field }}>
-      {{ label(form, field, helper_opts ++ attr_opts ++ @opts, do: children(assigns, field)) }}
+      <label :attrs={{ helper_opts ++ attr_opts ++ @opts ++ input_id(form, field) }}>
+        <slot>{{ Phoenix.Naming.humanize(field) }}</slot>
+      </label>
     </InputContext>
     """
   end
 
-  def children(assigns, field) do
-    ~H"<slot>{{ Phoenix.Naming.humanize(field) }}</slot>"
+  defp input_id(form, field) when is_nil(form) or is_nil(field), do: []
+
+  defp input_id(form, field) do
+    [for: Phoenix.HTML.Form.input_id(form, field)]
   end
 end

--- a/lib/surface/components/link.ex
+++ b/lib/surface/components/link.ex
@@ -1,11 +1,12 @@
 defmodule Surface.Components.Link do
   @moduledoc """
-  Defines a hyperlink.
+  Generates a link to the given URL.
 
-  Provides a wrapper for Phoenix.HTML.Link's `link/2` function.
+  Provides similar capabilities to Phoenix's built-in `link/2`
+  function.
 
-  All options passed via `opts` will be sent to `link/2`, `label` and `class` can
-  be set directly and will override anything in `opts`.
+  Options `label` and `class` can be set directly and will override anything in `opts`.
+  All other options are forwarded to the underlying <a> tag.
 
   ## Examples
   ```
@@ -27,25 +28,27 @@ defmodule Surface.Components.Link do
 
   use Surface.Component
 
-  import Phoenix.HTML.Link, only: [link: 2]
-
-  @doc "Place to link to"
+  @doc "The page to link to"
   prop to, :string, required: true
+
+  @doc "The method to use with the link"
+  prop method, :atom, default: :get
 
   @doc "Class or classes to apply to the link"
   prop class, :css_class
 
-  @doc "Keyword with options to be passed down to `link/2`"
-  prop opts, :keyword, default: []
-
   @doc """
-  The label for the generated `<a>` alement, if no content (default slot) is
-  provided.
+  The label for the generated `<a>` alement, if no content (default slot) is provided.
   """
   prop label, :string
 
   @doc "Triggered on click"
   prop click, :event
+
+  @doc """
+  Additional attributes to add onto the generated element
+  """
+  prop opts, :keyword, default: []
 
   @doc """
   The content of the generated `<a>` element. If no content is provided,
@@ -54,10 +57,39 @@ defmodule Surface.Components.Link do
   slot default
 
   def render(assigns) do
-    children = ~H"<slot>{{ @label }}</slot>"
-
     ~H"""
-    {{ link [to: @to] ++ prop_to_attr_opts(@class, :class) ++ @opts ++ event_to_opts(@click, :phx_click), do: children }}
+    <a
+      class={{ @class }}
+      href={{ @to }}
+      :attrs={{ @opts ++ event_to_opts(@click, :phx_click) |> opts_to_attrs(assigns) }}
+    ><slot>{{ @label }}</slot></a>
     """
+  end
+
+  defp opts_to_attrs(opts, assigns) do
+    for {key, value} <- opts do
+      case key do
+        :csrf_token -> {:"data-csrf", value}
+        :phx_click -> {:"phx-click", value}
+        :phx_target -> {:"phx-target", value}
+        :method -> method_to_attrs(value, assigns.to)
+        :data -> data_to_attrs(value)
+        _ -> {key, value}
+      end
+    end
+    |> List.flatten()
+  end
+
+  defp method_to_attrs(method, to) do
+    case method do
+      :get -> []
+      _ -> ["data-method": method, "data-to": to, rel: "nofollow"]
+    end
+  end
+
+  defp data_to_attrs(data) when is_list(data) do
+    for {key, value} <- data do
+      {:"data-#{key}", value}
+    end
   end
 end

--- a/test/components/label_test.exs
+++ b/test/components/label_test.exs
@@ -4,7 +4,7 @@ defmodule Surface.Components.LabelTest do
   alias Surface.Components.Form
   alias Surface.Components.Form.{Field, Label}
 
-  test "generates a <label> passing any opts to the underlying label/3" do
+  test "generates a <label> passing any opts to the underlying html element" do
     html =
       render_surface do
         ~H"""
@@ -12,7 +12,7 @@ defmodule Surface.Components.LabelTest do
         """
       end
 
-    assert html =~ ~r[<label (.+) id="my_id">(.+)</label>]
+    assert html =~ ~r[<label id="my_id">(.+)</label>]s
   end
 
   test "property class" do
@@ -45,7 +45,7 @@ defmodule Surface.Components.LabelTest do
         """
       end
 
-    assert html =~ ~S(<label for="user_name">Name</label>)
+    assert html =~ ~r[<label for="user_name">(.+)</label>]s
   end
 
   test "use context's form and field by default" do
@@ -60,7 +60,7 @@ defmodule Surface.Components.LabelTest do
         """
       end
 
-    assert html =~ ~S(<label for="user_name">Name</label>)
+    assert html =~ ~r[<label for="user_name">(.+)</label>]s
   end
 end
 

--- a/test/components/link_test.exs
+++ b/test/components/link_test.exs
@@ -98,13 +98,14 @@ defmodule Surface.Components.LinkTest do
       end
 
     assert html =~ """
-           <a class="link" \
+           <a \
            data-confirm="Really?" \
            data-csrf="token" \
            data-method="delete" \
            data-to="/users/1" \
-           href="/users/1" \
-           rel="nofollow">user</a>
+           rel="nofollow" \
+           class="link" \
+           href="/users/1">user</a>
            """
   end
 
@@ -117,7 +118,7 @@ defmodule Surface.Components.LinkTest do
       end
 
     assert html =~ """
-           <a href="/users/1" phx-click="my_click"></a>
+           <a phx-click="my_click" href="/users/1"></a>
            """
   end
 
@@ -131,7 +132,7 @@ defmodule Surface.Components.LinkTest do
 
     assert html =~ ~r"""
            <div>
-             <a href="/users/1" phx-click="my_click" phx-target=".+"></a>
+             <a phx-click="my_click" phx-target=".+" href="/users/1"></a>
            </div>
            """
   end


### PR DESCRIPTION
Fixes #262.

In order to pass all tests for the `Link` component I had to jump through a few hoops and do a "mini" implementation of #255 (e.g. translating the `data` option to `"data-x"` tags). As it stands, I only implemented the cases needed to pass the tests, but not general cases like changing names with "_" to "-".

In other components like `LivePatch` we don't have any translation and rely on the user doing it manually e.g. `"data-confirm": "Really?"` instead of `data: [confirm: "Really?"]`. However, I did not want to change the tests and remove functionality of `Link` to match `LivePatch` without discussing it firsts.

What do you think?

