### PR TITLE
Improve Link component compatibility with Phoenix link/2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Surface.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      env: [csrf_token_reader: {Plug.CSRFProtection, :get_csrf_token_for, []}]
     ]
   end
 


### PR DESCRIPTION
Follow-up to #272 and #273.

Surface's `<Link>` component should now behave as Phoenix's `link/2`.
I replicated most of their test cases and fixed a couple of issues that emerged (mainly around how we handle csrf tokens).