### PR TITLE
Allow question mark as a valid char in tag attribute name

### DIFF
--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -106,7 +106,12 @@ defmodule Surface.Compiler.Parser do
     |> wrap()
     |> post_traverse(:attribute_value)
 
-  attr_name = ascii_string([?a..?z, ?0..?9, ?A..?Z, ?-, ?., ?_, ?:, ?@], min: 1)
+  # Follow the rules of XML Names and Tokens plus "@" as a first char
+  # https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Name
+  attr_start_char = ascii_string([?a..?z, ?A..?Z, ?_, ?:, ?@], 1)
+  attr_name_char = ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_, ?:, ?-, ?., ??], min: 0)
+  attr_name = attr_start_char |> concat(attr_name_char) |> reduce({Enum, :join, [""]})
+
   whitespace = ascii_string([?\s, ?\n], min: 0)
 
   attribute =

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -169,6 +169,19 @@ defmodule HtmlTagTest do
              """
     end
 
+    test "with `@`, `:`, `_` as first char" do
+      html =
+        render_surface do
+          ~H"""
+          <div click?="open = true" @click="open = true" :click="open = true" />
+          """
+        end
+
+      assert html =~ """
+             <div click?="open = true" @click="open = true" :click="open = true"></div>
+             """
+    end
+
     test "with `@` and `.`" do
       html =
         render_surface do


### PR DESCRIPTION
Fix #275 

I followed the rules for attribute name here: https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Name

It's maybe a little bit too complicate. As an alternative, we could simply add `??` in the current implementation.

```diff
- attr_name = ascii_string([?a..?z, ?0..?9, ?A..?Z, ?-, ?., ?_, ?:, ?@], min: 1)
+ attr_name = ascii_string([?a..?z, ?0..?9, ?A..?Z, ?-, ?., ?_, ?:, ?@, ??], min: 1)
```