### PR TITLE
Support full list of void elements from HTTP specification

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -51,15 +51,18 @@ defmodule Surface.Compiler do
     "base",
     "br",
     "col",
+    "command",
+    "embed",
     "hr",
     "img",
     "input",
+    "keygen",
     "link",
     "meta",
     "param",
-    "command",
-    "keygen",
-    "source"
+    "source",
+    "track",
+    "wbr"
   ]
 
   defmodule ParseError do

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -137,15 +137,18 @@ defmodule Surface.Compiler.Parser do
       string("base"),
       string("br"),
       string("col"),
+      string("command"),
+      string("embed"),
       string("hr"),
       string("img"),
       string("input"),
+      string("keygen"),
       string("link"),
       string("meta"),
       string("param"),
-      string("command"),
-      string("keygen"),
-      string("source")
+      string("source"),
+      string("track"),
+      string("wbr")
     ])
 
   void_element_node =


### PR DESCRIPTION
For some context:

- This started with [this PR on surface_formatter](https://github.com/surface-ui/surface_formatter/pull/12).
- [Here's the list of void elements from the HTTP spec that I used](https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element).

From @msaraiva:

> I think we should update our list on the parser/compiler to have all of them, including the possibly deprecated ones.