### PR TITLE
Warn if prop is required and has default value

### DIFF
--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -260,6 +260,7 @@ defmodule Surface.API do
          :ok <- validate_opts_keys(func, name, type, opts),
          :ok <- validate_opts(func, type, opts),
          :ok <- validate_required_opts(func, type, opts) do
+      maybe_warn_required_prop_with_default_value(func, type, opts, caller)
       :ok
     else
       {:error, message} ->
@@ -338,6 +339,18 @@ defmodule Surface.API do
       end
     end)
   end
+
+  defp maybe_warn_required_prop_with_default_value(:prop, _, opts, caller) do
+    if Keyword.get(opts, :required, false) and Keyword.has_key?(opts, :default) do
+      IOHelper.warn(
+        "setting a default value on a required prop has no effect. Either set the default value or set the prop as required, but not both.",
+        caller,
+        fn _ -> caller.line end
+      )
+    end
+  end
+
+  defp maybe_warn_required_prop_with_default_value(_, _, _, _), do: nil
 
   defp validate_required_opts(func, type, opts) do
     case get_required_opts(func, type, opts) -- Keyword.keys(opts) do

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -260,7 +260,7 @@ defmodule Surface.API do
          :ok <- validate_opts_keys(func, name, type, opts),
          :ok <- validate_opts(func, type, opts),
          :ok <- validate_required_opts(func, type, opts) do
-      maybe_warn_required_prop_with_default_value(func, type, opts, caller)
+      maybe_warn_mutually_exclusive_opts(func, type, opts, caller)
       :ok
     else
       {:error, message} ->
@@ -340,7 +340,7 @@ defmodule Surface.API do
     end)
   end
 
-  defp maybe_warn_required_prop_with_default_value(:prop, _, opts, caller) do
+  defp maybe_warn_mutually_exclusive_opts(:prop, _, opts, caller) do
     if Keyword.get(opts, :required, false) and Keyword.has_key?(opts, :default) do
       IOHelper.warn(
         "setting a default value on a required prop has no effect. Either set the default value or set the prop as required, but not both.",
@@ -350,7 +350,7 @@ defmodule Surface.API do
     end
   end
 
-  defp maybe_warn_required_prop_with_default_value(_, _, _, _), do: nil
+  defp maybe_warn_mutually_exclusive_opts(_, _, _, _), do: nil
 
   defp validate_required_opts(func, type, opts) do
     case get_required_opts(func, type, opts) -- Keyword.keys(opts) do

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -407,7 +407,7 @@ defmodule Surface.APITest do
     assert get_docs(Surface.PropertiesTest.Components.MyComponent) == """
            ### Properties
 
-           * **label** *:string, required: true, default: ""* - The label.
+           * **label** *:string, required: true* - The label.
            * **class** *:css_class* - The class.
            """
   end
@@ -418,7 +418,7 @@ defmodule Surface.APITest do
 
            ### Properties
 
-           * **label** *:string, required: true, default: ""* - The label.
+           * **label** *:string, required: true* - The label.
            * **class** *:css_class* - The class.
            """
   end

--- a/test/support/properties_test_components.ex
+++ b/test/support/properties_test_components.ex
@@ -3,7 +3,7 @@ defmodule Surface.PropertiesTest.Components do
     use Surface.Component
 
     @doc "The label"
-    prop label, :string, required: true, default: ""
+    prop label, :string, required: true
 
     @doc "The class"
     prop class, :css_class
@@ -23,7 +23,7 @@ defmodule Surface.PropertiesTest.Components do
     """
 
     @doc "The label"
-    prop label, :string, required: true, default: ""
+    prop label, :string, required: true
 
     @doc "The class"
     prop class, :css_class
@@ -41,7 +41,7 @@ defmodule Surface.PropertiesTest.Components do
     @moduledoc false
 
     @doc "The label"
-    prop label, :string, required: true, default: ""
+    prop label, :string, required: true
 
     @doc "The class"
     prop class, :css_class


### PR DESCRIPTION
Fixes #281 

Thanks @colinsmetz! This change caught 3 misuses of a prop with a default value and the required opt set at true. 